### PR TITLE
270/271 place of service code references 'pos' codeset

### DIFF
--- a/map/270.4010.X092.A1.xml
+++ b/map/270.4010.X092.A1.xml
@@ -1761,45 +1761,7 @@
                         <name>Industry Code</name>
                         <usage>R</usage>
                         <seq>02</seq>
-                        <valid_codes>
-                          <code>03</code>
-                          <code>04</code>
-                          <code>05</code>
-                          <code>06</code>
-                          <code>07</code>
-                          <code>08</code>
-                          <code>11</code>
-                          <code>12</code>
-                          <code>15</code>
-                          <code>20</code>
-                          <code>21</code>
-                          <code>22</code>
-                          <code>23</code>
-                          <code>24</code>
-                          <code>25</code>
-                          <code>26</code>
-                          <code>31</code>
-                          <code>32</code>
-                          <code>33</code>
-                          <code>34</code>
-                          <code>41</code>
-                          <code>42</code>
-                          <code>50</code>
-                          <code>51</code>
-                          <code>52</code>
-                          <code>53</code>
-                          <code>54</code>
-                          <code>55</code>
-                          <code>56</code>
-                          <code>60</code>
-                          <code>61</code>
-                          <code>62</code>
-                          <code>65</code>
-                          <code>71</code>
-                          <code>72</code>
-                          <code>81</code>
-                          <code>99</code>
-                        </valid_codes>
+                        <valid_codes external="pos"/>
                       </element>
                       <element xid="III03">
                         <data_ele>1136</data_ele>
@@ -2759,45 +2721,7 @@
                           <name>Industry Code</name>
                           <usage>R</usage>
                           <seq>02</seq>
-                          <valid_codes>
-                            <code>03</code>
-                            <code>04</code>
-                            <code>05</code>
-                            <code>06</code>
-                            <code>07</code>
-                            <code>08</code>
-                            <code>11</code>
-                            <code>12</code>
-                            <code>15</code>
-                            <code>20</code>
-                            <code>21</code>
-                            <code>22</code>
-                            <code>23</code>
-                            <code>24</code>
-                            <code>25</code>
-                            <code>26</code>
-                            <code>31</code>
-                            <code>32</code>
-                            <code>33</code>
-                            <code>34</code>
-                            <code>41</code>
-                            <code>42</code>
-                            <code>50</code>
-                            <code>51</code>
-                            <code>52</code>
-                            <code>53</code>
-                            <code>54</code>
-                            <code>55</code>
-                            <code>56</code>
-                            <code>60</code>
-                            <code>61</code>
-                            <code>62</code>
-                            <code>65</code>
-                            <code>71</code>
-                            <code>72</code>
-                            <code>81</code>
-                            <code>99</code>
-                          </valid_codes>
+                          <valid_codes external="pos"/>
                         </element>
                         <element xid="III03">
                           <data_ele>1136</data_ele>

--- a/map/271.4010.X092.A1.xml
+++ b/map/271.4010.X092.A1.xml
@@ -2411,45 +2411,7 @@
                           <name>Industry Code</name>
                           <usage>R</usage>
                           <seq>02</seq>
-                          <valid_codes>
-                            <code>03</code>
-                            <code>04</code>
-                            <code>05</code>
-                            <code>06</code>
-                            <code>07</code>
-                            <code>08</code>
-                            <code>11</code>
-                            <code>12</code>
-                            <code>15</code>
-                            <code>20</code>
-                            <code>21</code>
-                            <code>22</code>
-                            <code>23</code>
-                            <code>24</code>
-                            <code>25</code>
-                            <code>26</code>
-                            <code>31</code>
-                            <code>32</code>
-                            <code>33</code>
-                            <code>34</code>
-                            <code>41</code>
-                            <code>42</code>
-                            <code>50</code>
-                            <code>51</code>
-                            <code>52</code>
-                            <code>53</code>
-                            <code>54</code>
-                            <code>55</code>
-                            <code>56</code>
-                            <code>60</code>
-                            <code>61</code>
-                            <code>62</code>
-                            <code>65</code>
-                            <code>71</code>
-                            <code>72</code>
-                            <code>81</code>
-                            <code>99</code>
-                          </valid_codes>
+                          <valid_codes external="pos"/>
                         </element>
                         <element xid="III03">
                           <data_ele>1136</data_ele>
@@ -4328,45 +4290,7 @@
                             <name>Industry Code</name>
                             <usage>R</usage>
                             <seq>02</seq>
-                            <valid_codes>
-                              <code>03</code>
-                              <code>04</code>
-                              <code>05</code>
-                              <code>06</code>
-                              <code>07</code>
-                              <code>08</code>
-                              <code>11</code>
-                              <code>12</code>
-                              <code>15</code>
-                              <code>20</code>
-                              <code>21</code>
-                              <code>22</code>
-                              <code>23</code>
-                              <code>24</code>
-                              <code>25</code>
-                              <code>26</code>
-                              <code>31</code>
-                              <code>32</code>
-                              <code>33</code>
-                              <code>34</code>
-                              <code>41</code>
-                              <code>42</code>
-                              <code>50</code>
-                              <code>51</code>
-                              <code>52</code>
-                              <code>53</code>
-                              <code>54</code>
-                              <code>55</code>
-                              <code>56</code>
-                              <code>60</code>
-                              <code>61</code>
-                              <code>62</code>
-                              <code>65</code>
-                              <code>71</code>
-                              <code>72</code>
-                              <code>81</code>
-                              <code>99</code>
-                            </valid_codes>
+                            <valid_codes external="pos"/>
                           </element>
                           <element xid="III03">
                             <data_ele>1136</data_ele>


### PR DESCRIPTION
I changed the 270 and 271 maps to reference codes.xml:pos.

Inspired by receiving a '49' place of service code from Anthem Blue Cross in a 271 response, which is included in the 'pos' codeset but wasn't listed under the III02 sections.

One thing to note, however, that this codeset should only apply when III01 == "ZZ", but not when III01 == "BF" or "BK". I wasn't sure how to represent this properly.
