### PR TITLE
Related entity names are situational, not required.

### DIFF
--- a/pyx12/map/271.4010.X092.A1.xml
+++ b/pyx12/map/271.4010.X092.A1.xml
@@ -2481,7 +2481,7 @@
                       <repeat>1</repeat>
                       <segment xid="NM1">
                         <name>Subscriber Benefit Related Entity Name</name>
-                        <usage>R</usage>
+                        <usage>S</usage>
                         <pos>340</pos>
                         <max_use>1</max_use>
                         <element xid="NM101">
@@ -4359,7 +4359,7 @@
                         <repeat>1</repeat>
                         <segment xid="NM1">
                           <name>Dependent Benefit Related Entity Name</name>
-                          <usage>R</usage>
+                          <usage>S</usage>
                           <pos>340</pos>
                           <max_use>1</max_use>
                           <element xid="NM101">


### PR DESCRIPTION
Related Entities to the subscriber and dependent don't require the NM1 segment.

See 004010X092-271-2120C-NM1 (p. 250) and 004010X092-271-2120D-NM1 (p.326) in the 271 spec.
