### PR TITLE
Wrap del cur_map in try/except UnboundLocalError

### DIFF
--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -273,7 +273,10 @@ def x12n_document(param, src_file, fd_997, fd_html,
     del node
     del src
     del control_map
-    del cur_map
+    try:
+        del cur_map
+    except UnboundLocalError:
+        pass
     try:
         if not valid or errh.get_error_count() > 0:
             return False


### PR DESCRIPTION
I was getting `UnboundLocalError` exceptions when processing some 837I 5010 files. 

`cur_map` is bound in some `if/elif/else` clauses, but is not bound at the top of `x12n_document`, where other variables that are deleted at the bottom of the function are initially bound.

Wrapping the `del cur_wrap` in a `try/except` clause seemed like the least invasive way to modify the code to prevent this exception.