### PR TITLE
New Claim Adjustment Reason Codes

### DIFF
--- a/pyx12/map/codes.xml
+++ b/pyx12/map/codes.xml
@@ -946,6 +946,70 @@
       <code>202</code>
       <code>203</code>
       <code>204</code>
+      <code>205</code>
+      <code>206</code>
+      <code>207</code>
+      <code>208</code>
+      <code>209</code>
+      <code>210</code>
+      <code>211</code>
+      <code>212</code>
+      <code>213</code>
+      <code>214</code>
+      <code>215</code>
+      <code>216</code>
+      <code>217</code>
+      <code>218</code>
+      <code>219</code>
+      <code>220</code>
+      <code>221</code>
+      <code>222</code>
+      <code>223</code>
+      <code>224</code>
+      <code>225</code>
+      <code>226</code>
+      <code>227</code>
+      <code>228</code>
+      <code>229</code>
+      <code>230</code>
+      <code>231</code>
+      <code>232</code>
+      <code>233</code>
+      <code>234</code>
+      <code>235</code>
+      <code>236</code>
+      <code>237</code>
+      <code>238</code>
+      <code>239</code>
+      <code>240</code>
+      <code>241</code>
+      <code>242</code>
+      <code>243</code>
+      <code>244</code>
+      <code>245</code>
+      <code>246</code>
+      <code>247</code>
+      <code>248</code>
+      <code>249</code>
+      <code>250</code>
+      <code>251</code>
+      <code>252</code>
+      <code>253</code>
+      <code>254</code>
+      <code>255</code>
+      <code>256</code>
+      <code>257</code>
+      <code>258</code>
+      <code>259</code>
+      <code>260</code>
+      <code>261</code>
+      <code>262</code>
+      <code>263</code>
+      <code>264</code>
+      <code>265</code>
+      <code>266</code>
+      <code>267</code>
+      <code>268</code>
       <code>A0</code>
       <code>A1</code>
       <code>A2</code>
@@ -999,6 +1063,29 @@
       <code>D19</code>
       <code>D20</code>
       <code>D21</code>
+      <code>P1</code>
+      <code>P2</code>
+      <code>P3</code>
+      <code>P4</code>
+      <code>P5</code>
+      <code>P6</code>
+      <code>P7</code>
+      <code>P8</code>
+      <code>P9</code>
+      <code>P10</code>
+      <code>P11</code>
+      <code>P12</code>
+      <code>P13</code>
+      <code>P14</code>
+      <code>P15</code>
+      <code>P16</code>
+      <code>P17</code>
+      <code>P18</code>
+      <code>P19</code>
+      <code>P20</code>
+      <code>P21</code>
+      <code>P22</code>
+      <code>P23</code>
       <code>W1</code>
     </version>
   </codeset>

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -273,7 +273,10 @@ def x12n_document(param, src_file, fd_997, fd_html,
     del node
     del src
     del control_map
-    del cur_map
+    try:
+        del cur_map
+    except UnboundLocalError:
+        pass
     try:
         if not valid or errh.get_error_count() > 0:
             return False


### PR DESCRIPTION
I was getting "is not a valid code for Adjustment Reason Code" errors, and discovered the codes in the 837I files I was processing were not in `map\codes.xml`, although they were listed in the latest update (11/1/2014) of the Claim Adjustment Reason Codes (http://www.wpc-edi.com/reference/codelists/healthcare/claim-adjustment-reason-codes/).

I added codes 205-268 and P1-P23.

I'm not sure if I succeeded in first resyncing with your changes to your master (to provide an initial binding to `cur_map` in `x12n_document.py`, rather than wrapping the `del cur_map` in a `try/except` clause). I followed the instructions here: https://help.github.com/articles/syncing-a-fork/

Testing your `cur_map` modification on the 837I files I was processing before does not generate any `UnboundLocalError` exceptions. Gaining approval to share the de-identified file will take some time (and may not be possible).