### PR TITLE
Handling blank lines in x12xml_simple.seg, x12file._parse_segment

### DIFF
--- a/pyx12/x12file.py
+++ b/pyx12/x12file.py
@@ -341,6 +341,10 @@ class X12Reader(X12Base):
         X12Base._parse_segment(self, seg_data)
         seg_id = seg_data.get_seg_id()
         if seg_id == 'IEA':
+            if not self.loops:
+                err_str = 'IEA loop with malformed preceding segment'
+                self._isa_error('000', err_str) # what is the correct code to use?
+                return # nothing to delete
             if self.loops[-1][0] != 'ISA':
                 # Unterminated GS loop
                 err_str = 'Unterminated Loop %s' % (self.loops[-1][0])

--- a/pyx12/x12xml_simple.py
+++ b/pyx12/x12xml_simple.py
@@ -69,7 +69,7 @@ class x12xml_simple(x12xml):
         self.writer.push(xname, attrib)
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
-            if child_node.usage == 'N' or seg_data.get('%02i' % (i + 1)).is_empty():
+            if child_node is None or child_node.usage == 'N' or seg_data.get('%02i' % (i + 1)).is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node_id)


### PR DESCRIPTION
I've been parsing a bunch of 835 files and found the following error terminating the parsing of many of them:

Traceback: Traceback (most recent call last):
...
  File "/usr/local/lib/python2.7/dist-packages/pyx12/x12n_document.py", line 240, in x12n_document
    xmldoc.seg(node, seg)
  File "/usr/local/lib/python2.7/dist-packages/pyx12/x12xml_simple.py", line 72, in seg
    if child_node.usage == 'N' or seg_data.get('%02i' % (i + 1)).is_empty():
AttributeError: 'NoneType' object has no attribute 'usage'

It appears this error is caused by 835 files that have blank lines, which I realize are malformed (out of spec), but my assumption is that the goal is to enable X12 parsing to continue (i.e., not terminate) while logging errors encountered during parsing.

I fixed this error by adding a `child_node is None` clause in that `if` statement, but I see there is an `else` clause at the end that raises an `EngineError`, so I'm not sure if this fix aligns with the desired behavior. 

Once this was fixed, a new `IndexError` was generated by `x12file._parse_segment()`, due - I think - to the presence of a blank line between an invalid IEA segment and a valid ISA segment.

I fixed this by adding a check for empty loops before checking the preceding loop to generate error messages, but was not sure what error code to use ... and am less confident that my fix in this file is consistent with desired behavior.

FWIW, here is the section of the log file that is generated for one of the files with errant blank lines and a malformed IEA segment:

20150306 16:37:58 pyx12.error_handler ERROR: Line:4383 SEG:1 - Segment
ISA*00 not found.  Started at /ISA_LOOP/IEA
20150306 16:37:58 pyx12.error_handler ERROR: No current segment in error_handler. Line:4383 SEG:1 - Segment identifier "
ISA" is invalid
20150306 16:37:58 pyx12.error_handler ERROR: Line:4610 SEG:5 - Segment IEA exceeded max count.  Found 2, should have 1
20150306 16:37:58 pyx12.error_handler ERROR: Line:4382 ISA:000 - IEA loop with malformed preceding segment

I thought it might be more useful to submit a pull request - even though one or both fixes may not be acceptable - to help more easily identify the problem areas. I suspect that if these errors are to be caught, a more extensive set of error checks will need to be added to one or both files.

If it is more helpful to simply report errors than trying to fix them, let me know, and I'll switch tactics.