### PR TITLE
Make 2300 loop not required after subscriber.

### DIFF
--- a/pyx12/map/837.5010.X222.A1.xml
+++ b/pyx12/map/837.5010.X222.A1.xml
@@ -2480,7 +2480,7 @@
               <!--End of 2010BB loop-->
               <loop xid="2300">
                 <name>Claim Information</name>
-                <usage>R</usage>
+                <usage>S</usage>
                 <pos>1300</pos>
                 <repeat>100</repeat>
                 <segment xid="CLM">


### PR DESCRIPTION
Fixes #38 

This PR makes the 5010/873 2300 loop usage Situational for the Subscriber loop, since it is not required if the Patient loop is present. Let me know if there is a better way to do this.