### PR TITLE
Python 2/3 compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ testenv/
 Backup/
 *.htm
 *.pyperf
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+    - 2.7
+    - 3.5
 
 python:
   - "2.7"

--- a/pyx12/__init__.py
+++ b/pyx12/__init__.py
@@ -2,6 +2,7 @@
 Validate and transform HIPAA X12 documents
 """
 
+from __future__ import unicode_literals
 __author__ = "John Holland <john.holland@swmbh.org>"
 __status__ = "production"
 from .version import __version__

--- a/pyx12/codes.py
+++ b/pyx12/codes.py
@@ -12,6 +12,7 @@
 External Codes interface
 """
 
+from __future__ import unicode_literals
 import os.path
 import logging
 from pkg_resources import resource_stream

--- a/pyx12/dataele.py
+++ b/pyx12/dataele.py
@@ -12,6 +12,7 @@
 Interface to normalized Data Elements
 """
 
+from __future__ import unicode_literals
 import os.path
 import logging
 import xml.etree.cElementTree as et

--- a/pyx12/decorators.py
+++ b/pyx12/decorators.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import functools
 import collections
 

--- a/pyx12/errh_xml.py
+++ b/pyx12/errh_xml.py
@@ -12,6 +12,7 @@
 Capture X12 Errors
 """
 
+from __future__ import unicode_literals
 import logging
 import tempfile
 import os

--- a/pyx12/error_997.py
+++ b/pyx12/error_997.py
@@ -14,6 +14,7 @@ Visitor - Visits an error_handler composite
 """
 
 #from types import *
+from __future__ import unicode_literals
 import time
 import logging
 

--- a/pyx12/error_999.py
+++ b/pyx12/error_999.py
@@ -13,6 +13,7 @@ Generates a 999 Response
 Visitor - Visits an error_handler composite
 """
 
+from __future__ import unicode_literals
 import time
 import logging
 import random

--- a/pyx12/error_debug.py
+++ b/pyx12/error_debug.py
@@ -14,6 +14,7 @@ Visitor - Visits an error_handler composite
 """
 
 # Intrapackage imports
+from __future__ import unicode_literals
 from .error_visitor import error_visitor
 
 

--- a/pyx12/error_handler.py
+++ b/pyx12/error_handler.py
@@ -12,6 +12,7 @@
 Interface to X12 Errors
 """
 
+from __future__ import unicode_literals
 import logging
 
 # Intrapackage imports

--- a/pyx12/error_html.py
+++ b/pyx12/error_html.py
@@ -12,6 +12,7 @@
 Generates HTML error output
 """
 
+from __future__ import unicode_literals
 import time
 import logging
 

--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -11,6 +11,7 @@
 """
 """
 
+from __future__ import unicode_literals
 from .errors import EngineError
 
 isa_errors = ('000', '001', '002', '003', '004', '005', '006', '007', '008',

--- a/pyx12/error_visitor.py
+++ b/pyx12/error_visitor.py
@@ -13,6 +13,7 @@ Visitor - Visits an error_handler composite
 """
 
 
+from __future__ import unicode_literals
 class error_visitor(object):
     """
     """

--- a/pyx12/errors.py
+++ b/pyx12/errors.py
@@ -12,6 +12,7 @@
 """
 
 
+from __future__ import unicode_literals
 class XML_Reader_Error(Exception):
     """Class for XML Reader errors."""
 

--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -10,6 +10,7 @@
 """
 Interface to a X12N IG Map
 """
+from __future__ import unicode_literals
 import logging
 import os.path
 import sys

--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -84,7 +84,7 @@ class x12_node(object):
                     return child
                 else:
                     if child.is_loop():
-                        return child.getnodebypath(str.join('/', pathl[1:]))
+                        return child.getnodebypath('/'.join(pathl[1:]))
                     else:
                         break
         raise EngineError('getnodebypath failed. Path "%s" not found' % path)
@@ -314,7 +314,7 @@ class map_if(x12_node):
                     if len(pathl) == 1:
                         return child
                     else:
-                        return child.getnodebypath(str.join('/', pathl[1:]))
+                        return child.getnodebypath('/'.join(pathl[1:]))
         raise EngineError('getnodebypath failed. Path "%s" not found' % spath)
 
     def getnodebypath2(self, path_str):
@@ -512,7 +512,7 @@ class loop_if(x12_node):
                         if len(pathl) == 1:
                             return child
                         else:
-                            return child.getnodebypath(str.join('/', pathl[1:]))
+                            return child.getnodebypath('/'.join(pathl[1:]))
                 elif child.is_segment() and len(pathl) == 1:
                     if pathl[0].find('[') == -1:  # No id to match
                         if pathl[0] == child.id:
@@ -1233,8 +1233,7 @@ class element_if(x12_node):
 # Validate based on data_elem_num
 # Then, validate on more specific criteria
         if (not data_type is None) and (data_type == 'R' or data_type[0] == 'N'):
-            elem_strip = str.replace(
-                str.replace(elem_val, '-', ''), '.', '')
+            elem_strip = elem_val.replace('-', '').replace('.', '')
             elem_len = len(elem_strip)
             if len(elem_strip) < min_len:
                 err_str = 'Data element "%s" (%s) is too short: len("%s") = %i < %i (min_len)' % \

--- a/pyx12/map_index.py
+++ b/pyx12/map_index.py
@@ -16,6 +16,7 @@ Locate the correct xml map file given:
     - Transaction Set Purpose Code (BHT02) (For 278 only)
 """
 
+from __future__ import unicode_literals
 import os.path
 import logging
 from pkg_resources import resource_stream

--- a/pyx12/map_override.py
+++ b/pyx12/map_override.py
@@ -16,6 +16,7 @@ NOT IMPLEMENTED
 """
 
 
+from __future__ import unicode_literals
 class map_override(object):
     """
     Apply local overrides to the current map. Overrides defined in a xml document.

--- a/pyx12/map_walker.py
+++ b/pyx12/map_walker.py
@@ -15,6 +15,7 @@ If seg indicates a loop has been entered, returns the first child segment node.
 If seg indicates a segment has been entered, returns the segment node.
 """
 
+from __future__ import unicode_literals
 import logging
 
 # Intrapackage imports

--- a/pyx12/nodeCounter.py
+++ b/pyx12/nodeCounter.py
@@ -11,6 +11,7 @@
 """
 Loop and segment counter
 """
+from __future__ import unicode_literals
 from collections import OrderedDict
 import pyx12.path
 from .decorators import dump_args

--- a/pyx12/params.py
+++ b/pyx12/params.py
@@ -16,6 +16,7 @@ Order of precedence:
  2. Config files as constructor parameters
  3. self.params - Defaults
 """
+from __future__ import unicode_literals
 from os.path import dirname, abspath, join, isdir, isfile, expanduser
 import sys
 import xml.etree.cElementTree as et

--- a/pyx12/path.py
+++ b/pyx12/path.py
@@ -26,6 +26,7 @@ SEG[434]02-1
 
 """
 
+from __future__ import unicode_literals
 import re
 
 from pyx12.errors import X12PathError

--- a/pyx12/rawx12file.py
+++ b/pyx12/rawx12file.py
@@ -12,6 +12,7 @@ Low level interface to an X12 data input stream.
 Iterates over segment line strings.
 Used by X12Reader.
 """
+from __future__ import unicode_literals
 
 # Intrapackage imports
 import pyx12.errors

--- a/pyx12/segment.py
+++ b/pyx12/segment.py
@@ -17,6 +17,7 @@ treated as a composite element with one sub-element.
 
 All indexing is zero based.
 """
+from __future__ import unicode_literals
 import re
 
 import pyx12.path

--- a/pyx12/syntax.py
+++ b/pyx12/syntax.py
@@ -15,6 +15,7 @@ X12 syntax validation functions
 """
 
 
+from __future__ import unicode_literals
 def is_syntax_valid(seg_data, syn):
     """
     Verifies the segment against the syntax

--- a/pyx12/test/test_codes.py
+++ b/pyx12/test/test_codes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.codes

--- a/pyx12/test/test_dataele.py
+++ b/pyx12/test/test_dataele.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.dataele

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.error_handler

--- a/pyx12/test/test_map_if_load.py
+++ b/pyx12/test/test_map_if_load.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.error_handler

--- a/pyx12/test/test_map_index.py
+++ b/pyx12/test/test_map_index.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.map_index

--- a/pyx12/test/test_map_unique.py
+++ b/pyx12/test/test_map_unique.py
@@ -1,5 +1,6 @@
 #    $Id: map_walker.py 1484 2011-10-22 02:06:12Z johnholland $
 
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.error_handler

--- a/pyx12/test/test_map_walker.py
+++ b/pyx12/test/test_map_walker.py
@@ -1,4 +1,5 @@
 #from os.path import dirname, abspath, join, isdir, isfile
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.error_handler

--- a/pyx12/test/test_params.py
+++ b/pyx12/test/test_params.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 import sys
 import os.path

--- a/pyx12/test/test_path.py
+++ b/pyx12/test/test_path.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.path

--- a/pyx12/test/test_rawx12file.py
+++ b/pyx12/test/test_rawx12file.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 try:
     from StringIO import StringIO

--- a/pyx12/test/test_segment.py
+++ b/pyx12/test/test_segment.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import pyx12.segment

--- a/pyx12/test/test_syntax.py
+++ b/pyx12/test/test_syntax.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import os.path
 import unittest

--- a/pyx12/test/test_validation.py
+++ b/pyx12/test/test_validation.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 from pyx12.validation import IsValidDataType

--- a/pyx12/test/test_x12context.py
+++ b/pyx12/test/test_x12context.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 #import tempfile
 try:

--- a/pyx12/test/test_x12file.py
+++ b/pyx12/test/test_x12file.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 try:
     from StringIO import StringIO

--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 try:
     from StringIO import StringIO

--- a/pyx12/test/test_xmlwriter.py
+++ b/pyx12/test/test_xmlwriter.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os.path
 import sys
 import os

--- a/pyx12/test/test_xmlx12_simple.py
+++ b/pyx12/test/test_xmlx12_simple.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 try:
     from StringIO import StringIO

--- a/pyx12/test/x12testdata.py
+++ b/pyx12/test/x12testdata.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 datafiles = {
     '834_lui_id': {
         'source': """ISA*00*          *00*          *ZZ*D00XXX         *ZZ*00AA           *070305*1832*U*00401*000701336*0*P*:~

--- a/pyx12/validation.py
+++ b/pyx12/validation.py
@@ -19,9 +19,11 @@ from .errors import IsValidError, EngineError
 try:
     # Python 3.x
     REGEX_MODE = re.S | re.ASCII
+    string_types = (str, )
 except AttributeError:
     # Python 2.x
     REGEX_MODE = re.S
+    string_types = (str, unicode)
 
 def IsValidDataType(str_val, data_type, charset='B', icvn='00401'):
     """
@@ -38,7 +40,7 @@ def IsValidDataType(str_val, data_type, charset='B', icvn='00401'):
     """
     if not data_type:
         return True
-    if not isinstance(str_val, str):
+    if not isinstance(str_val, string_types):
         return False
 
     try:

--- a/pyx12/validation.py
+++ b/pyx12/validation.py
@@ -11,6 +11,7 @@
 """
 X12 data element validation
 """
+from __future__ import unicode_literals
 import re
 
 # Intrapackage imports

--- a/pyx12/version.py
+++ b/pyx12/version.py
@@ -1,1 +1,2 @@
+from __future__ import unicode_literals
 __version__ = "2.3.3"

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -33,6 +33,13 @@ from . import path
 from .map_walker import walk_tree, pop_to_parent_loop  # get_pop_loops, get_push_loops
 
 
+try:  # Python 2.x
+    string_types = (str, unicode)
+except NameError:
+    # Python 3.x
+    string_types = (str, )
+
+
 class X12DataNode(object):
     """
     Capture the segment data and X12 definition for a loop subtree
@@ -515,7 +522,7 @@ class X12LoopDataNode(X12DataNode):
         """
         if isinstance(seg_obj, pyx12.segment.Segment):
             return seg_obj
-        elif isinstance(seg_obj, str):
+        elif isinstance(seg_obj, string_types):
             (seg_term, ele_term, subele_term) = self._get_terminators()
             assert seg_term is not None, 'seg_term is none, node contains no X12SegmentDataNode children?'
             assert ele_term is not None, 'seg_term is none, node contains no X12SegmentDataNode children?'

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -23,6 +23,7 @@ Interface to read and alter segments
 #import os.path
 
 # Intrapackage imports
+from __future__ import unicode_literals
 import pyx12
 from . import error_handler
 from . import errors

--- a/pyx12/x12file.py
+++ b/pyx12/x12file.py
@@ -18,6 +18,7 @@ Interface to an X12 data stream.
    837 HL tree
 """
 
+from __future__ import unicode_literals
 import codecs
 import sys
 import logging

--- a/pyx12/x12metadata.py
+++ b/pyx12/x12metadata.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import sys
 import os
 import os.path

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -13,6 +13,7 @@ Parse a ANSI X12N data file.  Validate against a map and codeset values.
 Create XML, HTML, and 997/999 documents based on the data file.
 """
 
+from __future__ import unicode_literals
 import logging
 
 # Intrapackage imports

--- a/pyx12/x12xml.py
+++ b/pyx12/x12xml.py
@@ -12,6 +12,7 @@
 Create an XML rendering of the X12 document
 """
 
+from __future__ import unicode_literals
 import os.path
 
 # Intrapackage imports

--- a/pyx12/x12xml_simple.py
+++ b/pyx12/x12xml_simple.py
@@ -12,6 +12,7 @@
 Create a XML rendering of the X12 document
 """
 
+from __future__ import unicode_literals
 from os.path import commonprefix
 import logging
 

--- a/pyx12/xmlwriter.py
+++ b/pyx12/xmlwriter.py
@@ -6,6 +6,7 @@
 # *  switch from deprecated string module to string methods
 # *  use PEP 8 style
 
+from __future__ import unicode_literals
 import sys
 #import codecs
 

--- a/pyx12/xmlx12_simple.py
+++ b/pyx12/xmlx12_simple.py
@@ -12,6 +12,7 @@
 Create an X12 document from a XML data file in the simple form
 """
 
+from __future__ import unicode_literals
 import xml.etree.cElementTree as et
 import logging
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps =
+  nose
+  coverage
+setenv =
+  PYTHONHASHSEED = 0
+usedevelop = True
+commands =
+  nosetests --with-coverage --cover-tests --cover-package=pyx12 --cover-erase {posargs:pyx12}


### PR DESCRIPTION
@azoner @lexhung Builds on #47, wherein Python 3 support was added to this library. This PR makes it easier to write code using pyx12 which works on both Python 2 _and_ Python 3. 

## Background
A common way of upgrading Python applications to use Python 3 is to first make it work on both Python 2 and Python 3. One step in this process is making all string functions work consistently with `unicode` objects, and consistently use `io.StringIO` instead of other stream classes. The updates in #47 made pyx12 Python-3-compatible, but you still needed to use `str` on _both_ Python 2 and Python 3. This means you can't consistently use `io.BytesIO` or `io.StringIO` and have it work on 2/3.

## Changes

The changes in this PR allow pyx12 to handle `unicode` objects on python 2, in addition to `str` objects. They should have no effect on python 3 behavior.
- Do not call `str.replace` and `str.join` directly; access them using the str/unicode objects themselves.
- When checking if something is a `str`, also include `unicode` on python 2.
- Add `from __future__ import unicode_literals` to all python files, which makes string behavior more similar between 2/3.

I also added `tox.ini` to make running the test suite across multiple python versions locally easier.

## Thanks!

Thanks for writing this library! Your work is very much appreciated!