### PR TITLE
verbose argument defaults; file() => open()

### DIFF
--- a/pyx12/examples/generate_spec.py
+++ b/pyx12/examples/generate_spec.py
@@ -27,7 +27,7 @@ def check_map_path_arg(map_path):
 
 def save_csv(rows, csv_file):
     import csv
-    fields = ['Ordinal', 'Id', 'NodeType', 'Name', 'FormattedName', 'Count', 'Section', 'RelativePath', 'FullPath', 'ParentPath', 'ParentName', 'LoopMaxUse', 
+    fields = ['Ordinal', 'Id', 'NodeType', 'Name', 'FormattedName', 'Count', 'Section', 'RelativePath', 'FullPath', 'ParentPath', 'ParentName', 'LoopMaxUse',
               'Usage', 'DataType', 'MinLength', 'MaxLength']
     with open(csv_file, 'wb') as outfile:
         writer = csv.DictWriter(outfile, fieldnames=fields, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
@@ -39,22 +39,22 @@ def save_csv(rows, csv_file):
 def save_mapping(rows, json_file):
     sections = sorted(list(set([x['Section'] for x in rows])))
     maps = {}
-    with file(json_file, 'w') as fd:
+    with open(json_file, 'w') as fd:
         fd.write('{')
         for s in sections:
             fd.write('"{section}": ['.format(section=s))
             s = [
                 {
-                    'Id': x['Id'],  
+                    'Id': x['Id'],
                     'Ordinal': x['Ordinal'],
-                    'Type': x['DataType'] if 'DataType' in x else None, 
-                    'FieldName': x['FormattedName'],  
-                    'X12Path': x['RelativePath'], 
-                    'FullPath': x['FullPath'],  
-                    'ParentPath': x['ParentPath'],  
-                    'ParentName': x['ParentName'],  
-                    'Usage': x['Usage'],  
-                    'MaxLength': x['MaxLength'],  
+                    'Type': x['DataType'] if 'DataType' in x else None,
+                    'FieldName': x['FormattedName'],
+                    'X12Path': x['RelativePath'],
+                    'FullPath': x['FullPath'],
+                    'ParentPath': x['ParentPath'],
+                    'ParentName': x['ParentName'],
+                    'Usage': x['Usage'],
+                    'MaxLength': x['MaxLength'],
             } for x in rows if x['Section'] == s and x['NodeType'] == 'element']
             s.sort(key=lambda item: item['Ordinal'])
             for item in s:
@@ -120,7 +120,7 @@ def main():
     parser.add_argument(
         '--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')
@@ -155,7 +155,7 @@ def main():
 
     src_filename = args.input_files[0]
     json_file = os.path.join(os.path.dirname(os.path.abspath(src_filename)), 'node_list.json')
-    with file(json_file, 'r') as fd:
+    with open(json_file, 'r') as fd:
         res = json.load(fd)
     rows = make_dict(res)
 

--- a/pyx12/examples/node_iterator.py
+++ b/pyx12/examples/node_iterator.py
@@ -144,7 +144,7 @@ def x12n_iterator(param, src_file, map_path=None):
                 'prefix_nodes': [last_x12_segment_path]
             }
             res_ordinal += 1
-            
+
         for (refdes, ele_ord, comp_ord, val) in seg.values_iterator():
             elepath = node.parent.get_path() + '/' + refdes
             if elepath in res:
@@ -203,7 +203,7 @@ def main():
     parser.add_argument(
         '--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')
@@ -246,7 +246,7 @@ def main():
                 continue
             res = x12n_iterator(param=param, src_file=src_filename, map_path=args.map_path)
             json_file = os.path.join(os.path.dirname(os.path.abspath(src_filename)), 'node_list.json')
-            with file(json_file, 'w') as fd:
+            with open(json_file, 'w') as fd:
                 json.dump(res, fd, indent=4)
 
         except IOError:

--- a/pyx12/scripts/x12html.py
+++ b/pyx12/scripts/x12html.py
@@ -58,7 +58,7 @@ def main():
     parser.add_argument(
         '--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')

--- a/pyx12/scripts/x12info.py
+++ b/pyx12/scripts/x12info.py
@@ -32,7 +32,7 @@ def check_map_path_arg(map_path):
 def main():
     import argparse
     parser = argparse.ArgumentParser(description='X12 File Metatdata')
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--eol', '-e', action='store_true', help="Add eol to each segment line")
@@ -82,7 +82,7 @@ def main():
                 json_file = os.path.join(args.outputdirectory , json_filename)
             else:
                 json_file = os.path.join(os.path.dirname(os.path.abspath(src_filename)), json_filename)
-            with file(json_file, 'w') as fd:
+            with open(json_file, 'w') as fd:
                 json.dump(res, fd, indent=4)
 
         except IOError:

--- a/pyx12/scripts/x12norm.py
+++ b/pyx12/scripts/x12norm.py
@@ -28,7 +28,7 @@ __date__ = pyx12.__date__
 def main():
     import argparse
     parser = argparse.ArgumentParser(description='X12 Validation')
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--eol', '-e', action='store_true', help="Add eol to each segment line")
@@ -52,7 +52,7 @@ def main():
         if not os.path.isfile(file_in):
             logger.error('Could not open file "%s"' % (file_in))
 
-        fd_out = tempfile.TemporaryFile()
+        fd_out = tempfile.TemporaryFile(mode="w+")
         src = pyx12.x12file.X12Reader(file_in)
         for seg_data in src:
             if args.fixcounting:

--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -59,7 +59,7 @@ def main():
     parser.add_argument(
         '--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')

--- a/pyx12/scripts/x12xml.py
+++ b/pyx12/scripts/x12xml.py
@@ -55,7 +55,7 @@ def main():
                         dest="configfile", default=None)
     parser.add_argument('--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')

--- a/pyx12/scripts/xmlx12.py
+++ b/pyx12/scripts/xmlx12.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -39,7 +39,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description='XML to X12 conversion')
     parser.add_argument('--log-file', '-l', action='store', dest="logfile", default=None)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--outputfile', '-o', action='store', help="X12 target filename")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ document or can translate to and from an XML representation of the data file."""
 
 setup(
     name="pyx12",
-    version="2.3.3",
+    version="2.3.4",
     long_description=long_description,
     license='BSD',
     description="HIPAA X12 validator, parser and converter",


### PR DESCRIPTION
Thank you for pyx12! I'm working under python3.7 and got errors from file() and "TypeError: '>' not supported between instances of 'NoneType' and 'int'" for the "verbose" arguments to the scripts. Please accept this submission to fix that.

Apologies for the en passant trailing whitespace removals (my vim config).

Thanks!
Fred

PS: I'm interested in using pyx12 to extract diagnoses from 5010 837I/P claims.