### PR TITLE
Fix a comparison error.

### DIFF
--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -59,7 +59,7 @@ def main():
     parser.add_argument(
         '--log-file', '-l', action='store', dest="logfile", default=None)
     parser.add_argument('--map-path', '-m', action='store', dest="map_path", default=None, type=check_map_path_arg)
-    parser.add_argument('--verbose', '-v', action='count')
+    parser.add_argument('--verbose', '-v', action='count', default=0)
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--quiet', '-q', action='store_true')
     parser.add_argument('--html', '-H', action='store_true')


### PR DESCRIPTION
This commit fixes the following error:

Traceback (most recent call last):
  File "/usr/local/bin/x12valid", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/pyx12/scripts/x12valid.py", line 90, in main
    if args.verbose > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'