### PR TITLE
Fix string instead of bytes-like object error.

### DIFF
--- a/pyx12/scripts/x12norm.py
+++ b/pyx12/scripts/x12norm.py
@@ -52,7 +52,7 @@ def main():
         if not os.path.isfile(file_in):
             logger.error('Could not open file "%s"' % (file_in))
 
-        fd_out = tempfile.TemporaryFile()
+        fd_out = tempfile.TemporaryFile(mode='w')
         src = pyx12.x12file.X12Reader(file_in)
         for seg_data in src:
             if args.fixcounting:


### PR DESCRIPTION
Running x12norm with python3 I received the following error:

Traceback (most recent call last):
  File "/usr/local/bin/x12norm", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/pyx12/scripts/x12norm.py", line 71, in main
    fd_out.write(seg_data.format() + eol)
TypeError: a bytes-like object is required, not 'str'

fd_out is a "tempfile.TemporaryFile()".

The tempfile docs state:
The mode parameter defaults to 'w+b' so that the file created can be read and
written without being closed. Binary mode is used so that it behaves
consistently on all platforms without regard for the data that is stored.

In other parts of the x12norm code mode 'w' is set explicitly so I think
it is okay to do so for the tempfile as well.  This commit does that.