### PR TITLE
Python3 compatibility issue with scripts/x12xml.py creating blocking error

### DIFF
--- a/pyx12/scripts/x12xml.py
+++ b/pyx12/scripts/x12xml.py
@@ -82,8 +82,9 @@ def main():
     if args.debug:
         logger.setLevel(logging.DEBUG)
         param.set('debug', True)
-    if args.verbose > 0:
-        logger.setLevel(logging.DEBUG)
+    if args.verbose is not None and type(args.verbose).__name__ == 'int':
+        if args.verbose > 0:
+            logger.setLevel(logging.DEBUG)
     if args.quiet:
         logger.setLevel(logging.ERROR)
 


### PR DESCRIPTION
Addresses issue reported in #48 

In Python3 boolean comparison operator usage with 0 when value is None are no longer equivalent.

Modification is made to the scripts/x12xml.py file to first check if args.verbose is not None and has a valid integer type before further evaluation with a boolean comparison operator.
