### PR TITLE
2.3.5 patch proposal: fixes for 834 5010X220A1 LS/LX/LE pos/repeat, setuptools deprecation fix

### DIFF
--- a/pyx12/codes.py
+++ b/pyx12/codes.py
@@ -14,7 +14,7 @@ External Codes interface
 
 import os.path
 import logging
-from pkg_resources import resource_stream
+from importlib.resources import files
 import xml.etree.cElementTree as et
 
 # Intrapackage imports
@@ -50,7 +50,7 @@ class ExternalCodes(object):
             code_fd = open(os.path.join(base_path, codes_file))
         else:
             logger.debug("Looking for codes file '{}' in pkg_resources".format(codes_file))
-            code_fd = resource_stream(__name__, os.path.join('map', codes_file))
+            code_fd = files(__name__).joinpath('map', codes_file).open('rb')
 
         self.exclude_list = exclude.split(',') if exclude is not None else []
 

--- a/pyx12/dataele.py
+++ b/pyx12/dataele.py
@@ -15,7 +15,7 @@ Interface to normalized Data Elements
 import os.path
 import logging
 import xml.etree.cElementTree as et
-from pkg_resources import resource_stream
+from importlib.resources import files
 
 # Intrapackage imports
 from pyx12.errors import EngineError
@@ -48,7 +48,7 @@ class DataElements(object):
             fd = open(os.path.join(base_path, dataele_file))
         else:
             logger.debug("Looking for data element definition file '{}' in pkg_resources".format(dataele_file))
-            fd = resource_stream(__name__, os.path.join('map', dataele_file))
+            fd = files(__name__).joinpath('map', dataele_file).open('rb')
         for eElem in et.parse(fd).iter('data_ele'):
             ele_num = eElem.get('ele_num')
             data_type = eElem.get('data_type')

--- a/pyx12/examples/generate_spec.py
+++ b/pyx12/examples/generate_spec.py
@@ -27,7 +27,7 @@ def check_map_path_arg(map_path):
 
 def save_csv(rows, csv_file):
     import csv
-    fields = ['Ordinal', 'Id', 'NodeType', 'Name', 'FormattedName', 'Count', 'Section', 'RelativePath', 'FullPath', 'ParentPath', 'ParentName', 'LoopMaxUse', 
+    fields = ['Ordinal', 'Id', 'NodeType', 'Name', 'FormattedName', 'Count', 'Section', 'RelativePath', 'FullPath', 'ParentPath', 'ParentName', 'LoopMaxUse',
               'Usage', 'DataType', 'MinLength', 'MaxLength']
     with open(csv_file, 'wb') as outfile:
         writer = csv.DictWriter(outfile, fieldnames=fields, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
@@ -45,16 +45,16 @@ def save_mapping(rows, json_file):
             fd.write('"{section}": ['.format(section=s))
             s = [
                 {
-                    'Id': x['Id'],  
+                    'Id': x['Id'],
                     'Ordinal': x['Ordinal'],
-                    'Type': x['DataType'] if 'DataType' in x else None, 
-                    'FieldName': x['FormattedName'],  
-                    'X12Path': x['RelativePath'], 
-                    'FullPath': x['FullPath'],  
-                    'ParentPath': x['ParentPath'],  
-                    'ParentName': x['ParentName'],  
-                    'Usage': x['Usage'],  
-                    'MaxLength': x['MaxLength'],  
+                    'Type': x['DataType'] if 'DataType' in x else None,
+                    'FieldName': x['FormattedName'],
+                    'X12Path': x['RelativePath'],
+                    'FullPath': x['FullPath'],
+                    'ParentPath': x['ParentPath'],
+                    'ParentName': x['ParentName'],
+                    'Usage': x['Usage'],
+                    'MaxLength': x['MaxLength'],
             } for x in rows if x['Section'] == s and x['NodeType'] == 'element']
             s.sort(key=lambda item: item['Ordinal'])
             for item in s:

--- a/pyx12/examples/node_iterator.py
+++ b/pyx12/examples/node_iterator.py
@@ -144,7 +144,7 @@ def x12n_iterator(param, src_file, map_path=None):
                 'prefix_nodes': [last_x12_segment_path]
             }
             res_ordinal += 1
-            
+
         for (refdes, ele_ord, comp_ord, val) in seg.values_iterator():
             elepath = node.parent.get_path() + '/' + refdes
             if elepath in res:

--- a/pyx12/map/834.5010.X220.A1.v2.xml
+++ b/pyx12/map/834.5010.X220.A1.v2.xml
@@ -2050,11 +2050,11 @@
           <!--End of 2320 loop-->
         </loop>
         <!--End of 2300 loop-->
-        <loop xid="2700_LS" pos="6800" usage="S" repeat="1" name="Additional Reporting Categories">
+        <loop xid="2700_LS" pos="6880" usage="S" repeat="&gt;1" name="Additional Reporting Categories">
           <segment xid="LS" usage="R" pos="6880" max_use="1" name="Additional Reporting Categories">
-            <element xid="LS01" data_ele="447" usage="R" seq="01" name="Loop Identifier Code" >
+            <element xid="LS01" data_ele="447" usage="R" seq="01" name="Loop Identifier Code">
               <valid_codes>
-                 <code>2700</code>
+                <code>2700</code>
               </valid_codes>
             </element>
           </segment>

--- a/pyx12/map/834.5010.X220.A1.xml
+++ b/pyx12/map/834.5010.X220.A1.xml
@@ -4790,8 +4790,8 @@
             <loop xid="2700_LS">
               <name>Additional Reporting Categories</name>
               <usage>S</usage>
-              <pos>6800</pos>
-              <repeat>1</repeat>
+              <pos>6880</pos>
+              <repeat>&gt;1</repeat>
               <segment xid="LS">
                 <name>Additional Reporting Categories</name>
                 <usage>R</usage>
@@ -4803,8 +4803,8 @@
                   <usage>R</usage>
                   <seq>01</seq>
                   <valid_codes>
-                        <code>2700</code>
-                      </valid_codes>
+                    <code>2700</code>
+                  </valid_codes>
                 </element>
               </segment>
               <!--End of LS segment-->
@@ -4973,12 +4973,12 @@
                     <name>Loop Identifier Code</name>
                     <usage>R</usage>
                     <seq>01</seq>
-                      <valid_codes>
-                        <code>2700</code>
-                      </valid_codes>
-                   </element>
+                    <valid_codes>
+                      <code>2700</code>
+                    </valid_codes>
+                  </element>
                 </segment>
-                <!--End of LE segment-->                
+                <!--End of LE segment-->
               </loop>
               <!--End of 2700 loop-->
             </loop>

--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -15,7 +15,7 @@ import os.path
 import sys
 import re
 import xml.etree.cElementTree as et
-from pkg_resources import resource_stream
+from importlib.resources import files
 
 # Intrapackage imports
 from .errors import EngineError
@@ -1535,7 +1535,7 @@ def load_map_file(map_file, param, map_path=None):
         map_fd = open(os.path.join(map_path, map_file))
     else:
         logger.debug("Looking for map file '{}' in pkg_resources".format(map_file))
-        map_fd = resource_stream(__name__, os.path.join('map', map_file))
+        map_fd = files(__name__).joinpath('map', map_file).open('rb')
     imap = None
     try:
         logger.debug('Create map from %s' % (map_file))

--- a/pyx12/map_index.py
+++ b/pyx12/map_index.py
@@ -18,7 +18,7 @@ Locate the correct xml map file given:
 
 import os.path
 import logging
-from pkg_resources import resource_stream
+from importlib.resources import files
 import xml.etree.cElementTree as et
 
 
@@ -44,7 +44,7 @@ class map_index(object):
             fd = open(os.path.join(base_path, maps_index_file))
         else:
             logger.debug("Looking for map index file '{}' in pkg_resources".format(maps_index_file))
-            fd = resource_stream(__name__, os.path.join('map', maps_index_file))
+            fd = files(__name__).joinpath('map', maps_index_file).open('rb')
         t = et.parse(fd)
         for v in t.iter('version'):
             icvn = v.get('icvn')

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -1,5 +1,5 @@
 #####################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -550,7 +550,7 @@ class X12LoopDataNode(X12DataNode):
     def seg_count(self):
         for child in [x for x in self.children if x.type == 'seg']:
             return child.seg_count
-        
+
     @property
     def cur_line_number(self):
         for child in [x for x in self.children if x.type == 'seg']:
@@ -699,7 +699,7 @@ class X12SegmentDataNode(X12DataNode):
         for loop in self.start_loops:
             yield {'node': loop, 'type': 'loop_start', 'id': loop.id}
         yield {'type': 'seg', 'id': self.id, 'segment': self.seg_data,
-               'start_loops': self.start_loops, 'end_loops': self.end_loops, 
+               'start_loops': self.start_loops, 'end_loops': self.end_loops,
                'seg_count': self.seg_count, 'cur_line_number': self.cur_line_number,}
 
     def copy(self):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ document or can translate to and from an XML representation of the data file."""
 
 setup(
     name="pyx12",
-    version="2.3.4",
+    version="2.3.5",
     long_description=long_description,
     license='BSD',
     description="HIPAA X12 validator, parser and converter",


### PR DESCRIPTION
Thank you for your hard work on this project @azoner! I've been studying this code and learning the depths of it, and testing its limits, and it's holding up well even today! There are a couple fixes I've prepared for your review, in anticipation that you make accept them and release a new patch to PyPi.

- Patched `map/834.5010.X220.A1.xml` and `map/834.5010.X220.A1.v2.xml`:
  - corrects `pos` and `repeat` values to match the HIPAA Standard, adds valid code `2700` to the `LS01` element
  - tab depth corrections
- setuptools for Python 3.13+ deprecated `pkg_resources/resource_stream`, and this update allows Python 3.13+ support
- Bumped the version (I can easily revert the version change if you prefer to do that)