### PR TITLE
Add Sphinx documentation build to main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,22 @@ jobs:
         run: uv sync --extra dev
       - name: Test with pytest
         run: uv run pytest
+
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: '3.12'
+      - name: Install docs dependencies
+        run: uv sync --extra docs
+      - name: Build HTML docs
+        run: uv run sphinx-build -b html docs docs/_build/html
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-html
+          path: docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Backup/
 .vscode/
 uv.lock
 .claude/settings.local.json
+docs/_build/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,107 @@
+API Reference
+=============
+
+Reading and writing X12
+-----------------------
+
+.. automodule:: pyx12.x12file
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.x12context
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.rawx12file
+   :members:
+   :undoc-members:
+
+Segments and paths
+------------------
+
+.. automodule:: pyx12.segment
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.path
+   :members:
+   :undoc-members:
+
+Validation
+----------
+
+.. automodule:: pyx12.validation
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.codes
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.dataele
+   :members:
+   :undoc-members:
+
+Map interface
+-------------
+
+.. automodule:: pyx12.map_if
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.map_index
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.map_walker
+   :members:
+   :undoc-members:
+
+XML rendering
+-------------
+
+.. automodule:: pyx12.x12xml
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.x12xml_simple
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.xmlx12_simple
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.xmlwriter
+   :members:
+   :undoc-members:
+
+Errors and reporting
+--------------------
+
+.. automodule:: pyx12.errors
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.error_handler
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.error_html
+   :members:
+   :undoc-members:
+
+Top-level driver
+----------------
+
+.. automodule:: pyx12.x12n_document
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.x12metadata
+   :members:
+   :undoc-members:
+
+.. automodule:: pyx12.params
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+"""Sphinx configuration for pyx12 documentation."""
+
+from importlib.metadata import version as _get_version
+
+project = "pyx12"
+author = "John Holland"
+copyright = "%Y, John Holland"
+
+release = _get_version("pyx12")
+version = ".".join(release.split(".")[:2])
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "furo"
+html_title = f"pyx12 {release}"
+
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}
+autodoc_member_order = "bysource"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+pyx12
+=====
+
+HIPAA X12 EDI document validator and converter. Parses ANSI X12N data files
+and validates them against an XML representation of the HIPAA Implementation
+Guidelines, generating 997 (4010) or 999 (5010) acknowledgement responses.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     "build>=1.0",
     "twine>=4.0",
 ]
+docs = [
+    "sphinx>=7.0",
+    "furo>=2024.1",
+]
 
 [project.urls]
 Homepage = "http://github.com/azoner/pyx12"


### PR DESCRIPTION
## Summary

Scaffolds a minimal Sphinx documentation setup and adds a documentation-build job to the existing \`main.yml\` workflow. \`Documentation = "https://pyx12.readthedocs.io/"\` was already declared in \`pyproject.toml\` but no Sphinx config existed in the repo to back it up.

## Changes

- \`docs/conf.py\` — Sphinx configuration. Uses [furo](https://pradyunsg.me/furo/) as the theme, reads the version dynamically via \`importlib.metadata\`, enables \`autodoc\`, \`napoleon\`, \`intersphinx\` (Python stdlib), and \`viewcode\`.
- \`docs/index.rst\` — landing page with a TOC.
- \`docs/api.rst\` — \`automodule\` reference for the public package surface, grouped into Reading/writing X12, Segments and paths, Validation, Map interface, XML rendering, Errors and reporting, and Top-level driver.
- \`pyproject.toml\` — new \`docs\` optional-dependencies extra (\`sphinx>=7\`, \`furo>=2024.1\`).
- \`.github/workflows/main.yml\` — new \`docs\` job runs on Python 3.12 alongside the existing test matrix; builds HTML and uploads it as a \`docs-html\` artifact.
- \`.gitignore\` — exclude \`docs/_build/\`.

## Notes

- Local build of \`sphinx-build -b html docs docs/_build/html\` succeeds; the CI job currently does **not** treat warnings as errors. There are 7 pre-existing minor docstring formatting warnings (field-list / indentation issues in \`x12context\`, \`segment\`, \`validation\`, \`map_if\`). Cleaning those up and adding \`-W --keep-going\` to the build is a sensible follow-up.
- The new check (\`Build documentation\`) is not currently in the master branch-protection rule's required-status-checks list. Add it later if you want docs failures to block PR merges.
- ReadTheDocs would still need a separate \`.readthedocs.yaml\` if you want RTD to auto-build; this PR doesn't add that yet (out of scope for "main action").

## Test plan

- [x] Local build: \`uv pip install -e ".[docs]"\` then \`sphinx-build -b html docs docs/_build/html\` succeeds (with non-fatal warnings)
- [x] Generated HTML renders the index, API reference, and per-module pages
- [ ] After merge, verify the \`docs-html\` artifact downloads correctly from the Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)