### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+formats:
+  - htmlzip


### PR DESCRIPTION
## Summary

Adds a v2 \`.readthedocs.yaml\` so the [pyx12.readthedocs.io](https://pyx12.readthedocs.io/) URL declared in \`pyproject.toml\` can actually back a build. Mirrors the docs CI job that landed in PR #89 — same Sphinx config, same \`docs\` extra, same theme.

## Config

\`\`\`yaml
version: 2

build:
  os: ubuntu-24.04
  tools:
    python: "3.12"

sphinx:
  configuration: docs/conf.py
  fail_on_warning: false

python:
  install:
    - method: pip
      path: .
      extra_requirements:
        - docs

formats:
  - htmlzip
\`\`\`

\`fail_on_warning\` matches the CI job (currently lenient; can tighten after the 7 stale docstring warnings are cleaned up).

## Activation steps after merge

1. Sign in at https://app.readthedocs.org/dashboard/
2. Import the \`azoner/pyx12\` repo (or, if it was previously imported, force a re-sync so it picks up \`.readthedocs.yaml\`)
3. Optional: configure the version policy (build only tags, branches, etc.) in the RTD project admin
4. Optional: set the default version on RTD to the latest stable tag once you ship 3.1.0 final

## Test plan

- [x] YAML structure follows RTD v2 schema (\`version: 2\`, \`build.os\`, \`build.tools\`, \`sphinx.configuration\`, \`python.install[].method == pip\`)
- [x] Mirrors the working CI build (\`docs/conf.py\`, \`[docs]\` extra) so a successful CI build implies a successful RTD build
- [ ] After merge + RTD import, verify a build succeeds and the rendered site loads at https://pyx12.readthedocs.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)