### PR TITLE
Add type hints to validation.py

### DIFF
--- a/pyx12/validation.py
+++ b/pyx12/validation.py
@@ -11,6 +11,7 @@
 """
 X12 data element validation
 """
+from __future__ import annotations
 import re
 
 # Intrapackage imports
@@ -18,7 +19,13 @@ from .errors import IsValidError, EngineError
 
 REGEX_MODE = re.S | re.ASCII
 
-def IsValidDataType(str_val, data_type, charset='B', icvn='00401'):
+
+def IsValidDataType(
+    str_val: str,
+    data_type: str,
+    charset: str = 'B',
+    icvn: str = '00401',
+) -> bool:
     """
     Is str_val a valid X12 data value
 
@@ -66,17 +73,19 @@ def IsValidDataType(str_val, data_type, charset='B', icvn='00401'):
         return False
     return True
 
-rec_N = re.compile(r"^-?[0-9]+", REGEX_MODE)
-rec_R = re.compile(r"^-?[0-9]*(\.[0-9]+)?", REGEX_MODE)
-rec_ID_E = re.compile(
-    r"""[^A-Z0-9!"&'()*+,\-\./:;?= a-z%~@\[\]_{}\\|<>#$]""", REGEX_MODE)
-rec_ID_E5 = re.compile(
-    r"""[^A-Z0-9!"&'()*+,\-\./:;?= a-z%~@\[\]_{}\\|<>^`#$]""", REGEX_MODE)
-rec_ID_B = re.compile(r"""[^A-Z0-9!"&'()*+,\-\./:;?= ]""", REGEX_MODE)
-rec_DT = re.compile(r"[^0-9]+", REGEX_MODE)
-rec_TM = re.compile(r"[^0-9]+", REGEX_MODE)
 
-def match_re(short_data_type, val):
+rec_N: re.Pattern[str] = re.compile(r"^-?[0-9]+", REGEX_MODE)
+rec_R: re.Pattern[str] = re.compile(r"^-?[0-9]*(\.[0-9]+)?", REGEX_MODE)
+rec_ID_E: re.Pattern[str] = re.compile(
+    r"""[^A-Z0-9!"&'()*+,\-\./:;?= a-z%~@\[\]_{}\\|<>#$]""", REGEX_MODE)
+rec_ID_E5: re.Pattern[str] = re.compile(
+    r"""[^A-Z0-9!"&'()*+,\-\./:;?= a-z%~@\[\]_{}\\|<>^`#$]""", REGEX_MODE)
+rec_ID_B: re.Pattern[str] = re.compile(r"""[^A-Z0-9!"&'()*+,\-\./:;?= ]""", REGEX_MODE)
+rec_DT: re.Pattern[str] = re.compile(r"[^0-9]+", REGEX_MODE)
+rec_TM: re.Pattern[str] = re.compile(r"[^0-9]+", REGEX_MODE)
+
+
+def match_re(short_data_type: str, val: str) -> bool:
     """
     :param short_data_type: simplified data type
     :type short_data_type: string
@@ -84,6 +93,7 @@ def match_re(short_data_type, val):
     :type val: string
     :return: True if matched, False if not
     :rtype: boolean
+    :raises EngineError: If short_data_type is not 'N' or 'R'
     """
     if short_data_type == 'N':
         rec = rec_N
@@ -98,7 +108,13 @@ def match_re(short_data_type, val):
         return False  # nothing matched
     return True
 
-def not_match_re(short_data_type, val, charset='B', icvn='00401'):
+
+def not_match_re(
+    short_data_type: str,
+    val: str,
+    charset: str = 'B',
+    icvn: str = '00401',
+) -> bool:
     """
     :param short_data_type: simplified data type
     :type short_data_type: string
@@ -108,6 +124,7 @@ def not_match_re(short_data_type, val, charset='B', icvn='00401'):
     :type charset: string
     :return: True if found invalid characters, False if none
     :rtype: boolean
+    :raises EngineError: If short_data_type or charset is unrecognized
     """
     if short_data_type in ('ID', 'AN'):
         if charset == 'E':  # extended charset
@@ -117,6 +134,8 @@ def not_match_re(short_data_type, val, charset='B', icvn='00401'):
                 rec = rec_ID_E
         elif charset == 'B':  # basic charset:
             rec = rec_ID_B
+        else:
+            raise EngineError('Unknown charset %r for data type %s' % (charset, short_data_type))
     elif short_data_type == 'DT':
         rec = rec_DT
     elif short_data_type == 'TM':
@@ -128,7 +147,8 @@ def not_match_re(short_data_type, val, charset='B', icvn='00401'):
         return True  # Invalid char matched
     return False
 
-def is_valid_date(data_type, val):
+
+def is_valid_date(data_type: str, val: str) -> bool:
     """
     :param data_type: Date type
     :type data_type: string
@@ -182,10 +202,12 @@ def is_valid_date(data_type, val):
         return False
     return True
 
-def is_valid_time(val):
+
+def is_valid_time(val: str) -> bool:
     """
     :param val: time value to be verified
     :type val: string
+    :rtype: boolean
     """
     try:
         if not_match_re('TM', val):
@@ -206,7 +228,12 @@ def is_valid_time(val):
         return False
     return True
 
-def contains_control_character(str_val, charset='B', icvn='00401'):
+
+def contains_control_character(
+    str_val: str,
+    charset: str = 'B',
+    icvn: str = '00401',
+) -> tuple[bool, str | None]:
     control_base = {
         chr(0x07): 'BEL',
         chr(0x09): 'HT',


### PR DESCRIPTION
## Summary

Adds full type annotations to the public validation functions and the module-level compiled regex patterns in [pyx12/validation.py](pyx12/validation.py). Same pattern as PRs #91 (segment.py) and #92 (x12file.py): \`from __future__ import annotations\`, modern union syntax.

## Changes

- All seven public functions get full signatures:
  - \`IsValidDataType(str_val: str, data_type: str, charset: str = 'B', icvn: str = '00401') -> bool\`
  - \`match_re(short_data_type: str, val: str) -> bool\`
  - \`not_match_re(short_data_type: str, val: str, charset: str = 'B', icvn: str = '00401') -> bool\`
  - \`is_valid_date(data_type: str, val: str) -> bool\`
  - \`is_valid_time(val: str) -> bool\`
  - \`contains_control_character(str_val: str, charset: str = 'B', icvn: str = '00401') -> tuple[bool, str | None]\`
- Module-level compiled regexes annotated as \`re.Pattern[str]\`.
- Stale ":raises:" docs added where now-explicit.

## Latent bug fixed

\`not_match_re()\` previously had no \`else\` branch when \`short_data_type\` is \`'ID'\` or \`'AN'\` but \`charset\` is neither \`'E'\` nor \`'B'\`. The local variable \`rec\` would never be assigned, and the next line (\`m = rec.search(val)\`) raised \`UnboundLocalError\` instead of a clean \`EngineError\`. The bug only triggers on unusual charset values, which is why the suite never caught it.

Now raises \`EngineError\` with the offending charset, matching the existing \`else: raise\` pattern for unknown \`short_data_type\`. Required for mypy's definite-assignment analysis to pass anyway.

## Verification

- \`mypy --ignore-missing-imports pyx12/validation.py\` → 0 issues
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)