### PR TITLE
Add type hints to map_index.py

### DIFF
--- a/pyx12/map_index.py
+++ b/pyx12/map_index.py
@@ -14,17 +14,31 @@ Locate the correct xml map file given:
     - Version / Release / Industry Identifier Code (GS08)
     - Transaction Set Purpose Code (BHT02) (For 278 only)
 """
-
+from __future__ import annotations
+from typing import IO, Any, TypedDict
 import os.path
 import logging
 import defusedxml.ElementTree as et
 from importlib.resources import files as _res_files
 
+
+class _MapEntry(TypedDict):
+    icvn: str | None
+    vriic: str | None
+    fic: str | None
+    tspc: str | None
+    map_file: str | None
+    abbr: str | None
+
+
 class map_index:
     """
     Interface to the maps.xml file
     """
-    def __init__(self, base_path=None):
+
+    maps: list[_MapEntry]
+
+    def __init__(self, base_path: str | None = None) -> None:
         """
         :param base_path: Override directory containing maps.xml.  If None,
                     uses package resource folder
@@ -33,6 +47,9 @@ class map_index:
         logger = logging.getLogger('pyx12')
         self.maps = []
         maps_index_file = 'maps.xml'
+        # ElementTree.parse accepts either a text- or binary-mode stream; the
+        # file source differs between override path and bundled package resource.
+        fd: IO[Any]
         if base_path is not None:
             logger.debug(f"Looking for map index file '{maps_index_file}' in map_path '{base_path}'")
             if not os.path.isdir(base_path):
@@ -49,11 +66,25 @@ class map_index:
                     self.add_map(icvn, _m.get('vriic'), _m.get('fic'),
                                  _m.get('tspc'), _m.text, _m.get('abbr'))
 
-    def add_map(self, icvn, vriic, fic, tspc, map_file, abbr):
+    def add_map(
+        self,
+        icvn: str | None,
+        vriic: str | None,
+        fic: str | None,
+        tspc: str | None,
+        map_file: str | None,
+        abbr: str | None,
+    ) -> None:
         self.maps.append({'icvn': icvn, 'vriic': vriic, 'fic': fic,
                           'tspc': tspc, 'map_file': map_file, 'abbr': abbr})
 
-    def get_filename(self, icvn, vriic, fic, tspc=None):
+    def get_filename(
+        self,
+        icvn: str | None,
+        vriic: str | None,
+        fic: str | None,
+        tspc: str | None = None,
+    ) -> str | None:
         """
         Get the map filename associated with the given icvn, vriic, fic,
         and tspc values
@@ -65,7 +96,13 @@ class map_index:
                 return a['map_file']
         return None
 
-    def get_abbr(self, icvn, vriic, fic, tspc=None):
+    def get_abbr(
+        self,
+        icvn: str | None,
+        vriic: str | None,
+        fic: str | None,
+        tspc: str | None = None,
+    ) -> str | None:
         """
         Get the informal abbreviation associated with the given icvn, vriic,
         fic, and tspc values
@@ -77,6 +114,6 @@ class map_index:
                 return a['abbr']
         return None
 
-    def print_all(self):
+    def print_all(self) -> None:
         for a in self.maps:
             print(a)


### PR DESCRIPTION
## Summary

Adds type annotations to [pyx12/map_index.py](pyx12/map_index.py). Continues the type-hints series (PRs #91-#94).

## Changes

- \`from __future__ import annotations\`
- \`TypedDict\` for the in-memory map-entry shape:
  \`\`\`python
  class _MapEntry(TypedDict):
      icvn: str | None
      vriic: str | None
      fic: str | None
      tspc: str | None
      map_file: str | None
      abbr: str | None
  \`\`\`
  All fields are \`str | None\` because each comes from \`Element.get('attr')\` or \`.text\`, both of which return \`Optional[str]\`.
- \`map_index.maps: list[_MapEntry]\` at class level.
- Full signatures for \`__init__\`, \`add_map\`, \`get_filename\`, \`get_abbr\`, \`print_all\`.

## # type: ignore note (none needed)

The two branches of \`__init__\` produce different file types — text-mode \`open(..., encoding='utf-8')\` for the override path, binary-mode \`Traversable.open('rb')\` for the bundled resource. \`ElementTree.parse\` accepts either, but mypy needs help unifying. Solved with a single explicit \`fd: IO[Any]\` declaration before the if/else, no \`# type: ignore\` required.

## Verification

- \`mypy --ignore-missing-imports pyx12/map_index.py\` → 0 issues
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)