### PR TITLE
Add type hints to rawx12file.py, params.py, xmlwriter.py, syntax.py

### DIFF
--- a/pyx12/params.py
+++ b/pyx12/params.py
@@ -16,6 +16,8 @@ Order of precedence:
  2. Config files as constructor parameters
  3. self.params - Defaults
 """
+from __future__ import annotations
+from typing import Any
 from os.path import dirname, abspath, join, isdir, isfile, expanduser
 import sys
 import defusedxml.ElementTree as et
@@ -23,11 +25,16 @@ import logging
 
 from pyx12.errors import EngineError
 
+
 class ParamsBase:
     """
     Base class for parameters
     """
-    def __init__(self):
+
+    logger: logging.Logger
+    params: dict[str, Any]
+
+    def __init__(self) -> None:
         self.logger = logging.getLogger('pyx12.params')
         self.params = {}
         #First, try relative path
@@ -42,7 +49,7 @@ class ParamsBase:
         self.params['simple_dtd'] = ''
         self.params['xmlout'] = 'simple'
 
-    def get(self, option):
+    def get(self, option: str) -> Any:
         """
         Get the value of the parameter specified by option
         :param option: Option name
@@ -53,7 +60,7 @@ class ParamsBase:
         else:
             return None
 
-    def set(self, option, value):
+    def set(self, option: str, value: Any) -> None:
         """
         Set the value of the parameter specified by option
         :param option: Option name
@@ -66,7 +73,7 @@ class ParamsBase:
         else:
             self.params[option] = value
 
-    def _read_config_file(self, filename):
+    def _read_config_file(self, filename: str) -> None:
         """
         Read program configuration from an XML file
 
@@ -88,7 +95,7 @@ class ParamsBase:
             self.logger.error(f'Read of configuration file "{filename}" failed')
             raise
 
-    def _set_option(self, option, value, valtype):
+    def _set_option(self, option: str | None, value: str | None, valtype: str | None) -> None:
         """
         Set the value of the parameter specified by option
         :param option: Option name
@@ -110,11 +117,12 @@ class ParamsBase:
         else:
             self.params[option] = value
 
+
 class ParamsUnix(ParamsBase):
     """
     Read options from XML configuration files
     """
-    def __init__(self, config_file=None):
+    def __init__(self, config_file: str | None = None) -> None:
         super().__init__()
         config_files = [join(sys.prefix, 'etc/pyx12.conf.xml'),
                         expanduser('~/.pyx12.conf.xml')]
@@ -128,11 +136,12 @@ class ParamsUnix(ParamsBase):
         else:
             self.logger.debug('No config file passed to the constructor')
 
+
 class ParamsWindows(ParamsBase):
     """
     Read options from XML configuration files
     """
-    def __init__(self, config_file=None):
+    def __init__(self, config_file: str | None = None) -> None:
         super().__init__()
         config_files = [join(sys.prefix, 'etc/pyx12.conf.xml')]
         for filename in config_files:
@@ -143,6 +152,8 @@ class ParamsWindows(ParamsBase):
             self.logger.debug(f'Read param file: {config_file}')
             self._read_config_file(config_file)
 
+
+params: type[ParamsBase]
 if sys.platform == 'win32':
     params = ParamsWindows
 else:

--- a/pyx12/rawx12file.py
+++ b/pyx12/rawx12file.py
@@ -12,6 +12,9 @@ Low level interface to an X12 data input stream.
 Iterates over segment line strings.
 Used by X12Reader.
 """
+from __future__ import annotations
+from collections.abc import Iterator
+from typing import TextIO
 
 # Intrapackage imports
 import pyx12.errors
@@ -20,12 +23,21 @@ import pyx12.segment
 DEFAULT_BUFSIZE = 8 * 1024
 ISA_LEN = 106
 
+
 class RawX12File:
     """
     Interface to an X12 data file
     """
 
-    def __init__(self, fin):
+    fd: TextIO
+    buffer: str
+    icvn: str
+    seg_term: str
+    ele_term: str
+    subele_term: str
+    repetition_term: str | None
+
+    def __init__(self, fin: TextIO) -> None:
         """
         Initialize the file X12 file reader
 
@@ -33,7 +45,7 @@ class RawX12File:
         :type fin: open file object
         """
         self.fd = fin
-        self.buffer = None
+        self.buffer = ''
         line = self.fd.read(ISA_LEN)
         if line[:3] != 'ISA':
             err_str = "First line does not begin with 'ISA': %s" % line[:3]
@@ -52,7 +64,7 @@ class RawX12File:
         self.buffer = line
         self.buffer += self.fd.read(DEFAULT_BUFSIZE)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         """
         Iterate over input lines
         Often, X12 files have a CR-LF after the segment delimiter.
@@ -70,9 +82,9 @@ class RawX12File:
             line = line.lstrip('\n\r')
             if line == '':
                 break
-            yield(line)
+            yield line
 
-    def get_term(self):
+    def get_term(self) -> tuple[str, str, str, str, str | None]:
         """
         Get the original terminators
 

--- a/pyx12/syntax.py
+++ b/pyx12/syntax.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright (c) 2001-2011 
+# Copyright (c) 2001-2011
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -10,8 +10,16 @@
 """
 X12 syntax validation functions
 """
+from __future__ import annotations
+from typing import Any
 
-def is_syntax_valid(seg_data, syn):
+import pyx12.segment
+
+
+def is_syntax_valid(
+    seg_data: pyx12.segment.Segment,
+    syn: list[Any],
+) -> tuple[bool, str | None]:
     """
     Verifies the segment against the syntax
     :param seg_data: data segment instance
@@ -105,20 +113,22 @@ def is_syntax_valid(seg_data, syn):
     #raise EngineError
     return (False, 'Syntax Type %s Not Found' % (syntax_str(syn)))
 
-def syntax_str(syntax):
+
+def syntax_str(syntax: list[Any]) -> str:
     """
     :rtype: string
     """
     output = syntax[0]
     for i in syntax[1:]:
-        output += '{:02d}'.format(i)
+        output += '{:02d}'.format(int(i))
     return output
 
-def syntax_ele_id_str(seg_id, ele_pos_list):
+
+def syntax_ele_id_str(seg_id: str | None, ele_pos_list: list[int]) -> str:
     """
     :rtype: string
     """
-    output = '' 
+    output = ''
     output += '{seg_id}{ele_pos:02d}'.format(seg_id=seg_id, ele_pos=ele_pos_list[0])
     for i in range(len(ele_pos_list) - 1):
         if i == len(ele_pos_list) - 2:

--- a/pyx12/xmlwriter.py
+++ b/pyx12/xmlwriter.py
@@ -5,8 +5,10 @@
 #    for correct character output
 # *  switch from deprecated string module to string methods
 # *  use PEP 8 style
-
+from __future__ import annotations
+from typing import TextIO
 import sys
+
 
 class XMLWriter:
     """
@@ -49,7 +51,12 @@ class XMLWriter:
     flush
     """
 
-    def __init__(self, out=sys.stdout, encoding="utf-8", indent=" "):
+    encoding: str
+    out: TextIO
+    stack: list[str]
+    indent: str
+
+    def __init__(self, out: TextIO = sys.stdout, encoding: str = "utf-8", indent: str = " ") -> None:
         """
         out      - a stream for the output
         encoding - an encoding used to wrap the output for unicode
@@ -63,7 +70,7 @@ class XMLWriter:
         self.indent = indent
         self._write('<?xml version="1.0" encoding="{}"?>\n'.format(encoding))
 
-    def doctype(self, root, pubid, sysid):
+    def doctype(self, root: str, pubid: str | None, sysid: str) -> None:
         """
         Create a document type declaration (no internal subset)
         """
@@ -72,12 +79,14 @@ class XMLWriter:
                 "<!DOCTYPE {} SYSTEM '{}'>\n".format(root, sysid))
         else:
             self._write(
-                "<!DOCTYPE {} PUBLIC '{}' '{}'>\n".format(root, pubid, sysid)) 
+                "<!DOCTYPE {} PUBLIC '{}' '{}'>\n".format(root, pubid, sysid))
 
-    def push(self, elem, attrs={}):
+    def push(self, elem: str, attrs: dict[str, str] | None = None) -> None:
         """
         Create an element which will have child elements
         """
+        if attrs is None:
+            attrs = {}
         self._indent()
         self._write("<" + elem)
         for (a, v) in attrs.items():
@@ -85,17 +94,19 @@ class XMLWriter:
         self._write(">\n")
         self.stack.append(elem)
 
-    def elem(self, elem, content, attrs={}):
+    def elem(self, elem: str, content: str | None, attrs: dict[str, str] | None = None) -> None:
         """
         Create an element with text content only
         """
+        if attrs is None:
+            attrs = {}
         self._indent()
         self._write("<" + elem)
         for (a, v) in attrs.items():
             self._write(" {}='{}'".format(a, self._escape_attr(v)))
         self._write(">{}</{}>\n".format(self._escape_cont(content), elem))
 
-    def empty(self, elem, attrs=None):
+    def empty(self, elem: str, attrs: dict[str, str] | None = None) -> None:
         """
         Create an empty element
         """
@@ -107,7 +118,7 @@ class XMLWriter:
             self._write(" {}='{}'".format(a, self._escape_attr(v)))
         self._write("/>\n")
 
-    def pop(self):
+    def pop(self) -> None:
         """
         Close an element started with the push() method
         """
@@ -117,25 +128,25 @@ class XMLWriter:
             self._indent()
             self._write("</{elem}>\n".format(elem=elem))
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.stack)
 
-    def _indent(self):
+    def _indent(self) -> None:
         self._write(self.indent * (len(self.stack) * 2))
 
-    def _escape_cont(self, text):
+    def _escape_cont(self, text: str | None) -> str | None:
         if text is None:
             return None
         return text.replace("&", "&amp;")\
             .replace("<", "&lt;").replace(">", "&gt;")
 
-    def _escape_attr(self, text):
+    def _escape_attr(self, text: str | None) -> str | None:
         if text is None:
             return None
         return text.replace("&", "&amp;") \
             .replace("'", "&apos;").replace("<", "&lt;")\
             .replace(">", "&gt;")
 
-    def _write(self, strval):
+    def _write(self, strval: str) -> None:
         # self.out.write(strval.encode(self.encoding))
         self.out.write(strval)


### PR DESCRIPTION
## Summary

Bundles the type-annotation pass for the four remaining small modules. All four pass \`mypy --ignore-missing-imports\` cleanly. Same pattern as earlier typing PRs (\`from __future__ import annotations\`, modern union syntax, class-level instance attribute declarations).

## Per-file notes

### [pyx12/rawx12file.py](pyx12/rawx12file.py)
- \`TextIO\` for the file handle parameter and \`self.fd\`.
- Tiny init tweak: \`self.buffer = None\` → \`self.buffer = ''\`. The attribute is overwritten unconditionally on the next read; the difference matters only if init raises before that read, in which case the instance is already broken. \`buffer\` can now be typed as \`str\` instead of \`str | None\`, eliminating None-narrowing in \`__iter__\`.

### [pyx12/params.py](pyx12/params.py)
- \`ParamsBase.params: dict[str, Any]\` — heterogeneous (str, bool, None).
- \`_set_option\` parameters typed as \`str | None\` since they come from XML attribute getters.
- Module-level \`params: type[ParamsBase]\` annotation for the platform alias.

### [pyx12/xmlwriter.py](pyx12/xmlwriter.py)
- Replaced \`attrs={}\` mutable default in \`push()\` and \`elem()\` with \`attrs=None\` + body normalization. \`empty()\` already used this pattern from PR S1; pulling \`push\`/\`elem\` into the same shape removes the last mutable defaults in the file. Public API is unchanged for callers that pass nothing, \`None\`, or \`{}\`.
- \`_escape_cont\` and \`_escape_attr\` keep their \`str | None -> str | None\` contract.

### [pyx12/syntax.py](pyx12/syntax.py)
- \`is_syntax_valid(seg_data: pyx12.segment.Segment, syn: list[Any]) -> tuple[bool, str | None]\`. \`syn\` is mixed-type because items arrive as parsed XML strings but are used as ints after \`int()\` conversion.
- \`syntax_str\` now does \`int(i)\` before \`'{:02d}'.format(...)\`, so a list like \`['P', '01', '02']\` formats correctly whether items arrive as strings or ints — matches what \`is_syntax_valid\` does internally.

## Verification

- \`mypy --ignore-missing-imports pyx12/rawx12file.py pyx12/params.py pyx12/xmlwriter.py pyx12/syntax.py\` → 0 issues across all 4 files
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)