### PR TITLE
Add type hints to seven small modules

### DIFF
--- a/pyx12/decorators.py
+++ b/pyx12/decorators.py
@@ -1,27 +1,33 @@
+from __future__ import annotations
+from collections.abc import Callable
+from typing import Any
 import collections.abc
 import functools
 
 # See https://wiki.python.org/moin/PythonDecoratorLibrary
 
-def dump_args(func):
+
+def dump_args(func: Callable[..., Any]) -> Callable[..., Any]:
     "This decorator dumps out the arguments passed to a function before calling it"
     argnames = func.__code__.co_varnames[:func.__code__.co_argcount]
     fname = func.__name__
 
-    def echo_func(*args, **kwargs):
+    def echo_func(*args: Any, **kwargs: Any) -> Any:
         print((fname, ":", ', '.join('%s=%r' % entry
             for entry in list(zip(argnames, args)) + list(kwargs.items()))))
         return func(*args, **kwargs)
 
     return echo_func
 
-def memoize(obj):
-    cache = obj.cache = {}
+
+def memoize(obj: Callable[..., Any]) -> Callable[..., Any]:
+    cache: dict[Any, Any] = {}
+    obj.cache = cache  # type: ignore[attr-defined]
 
     @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
+    def memoizer(*args: Any, **kwargs: Any) -> Any:
         if kwargs:  # frozenset is used to ensure hashability
-            key = args, frozenset(kwargs.items())
+            key: Any = (args, frozenset(kwargs.items()))
         else:
             key = args
         if key not in cache:
@@ -29,15 +35,21 @@ def memoize(obj):
         return cache[key]
     return memoizer
 
+
 class memoized:
     '''Decorator. Caches a function's return value each time it is called.
     If called later with the same arguments, the cached value is returned
     (not reevaluated).
     '''
-    def __init__(self, func):
+
+    func: Callable[..., Any]
+    cache: dict[Any, Any]
+
+    def __init__(self, func: Callable[..., Any]) -> None:
         self.func = func
         self.cache = {}
-    def __call__(self, *args):
+
+    def __call__(self, *args: Any) -> Any:
         if not isinstance(args, collections.abc.Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.
@@ -48,9 +60,11 @@ class memoized:
             value = self.func(*args)
             self.cache[args] = value
             return value
-    def __repr__(self):
+
+    def __repr__(self) -> str:
         '''Return the function's docstring.'''
-        return self.func.__doc__
-    def __get__(self, obj, objtype):
+        return self.func.__doc__ or ''
+
+    def __get__(self, obj: Any, objtype: Any) -> Callable[..., Any]:
         '''Support instance methods.'''
         return functools.partial(self.__call__, obj)

--- a/pyx12/error_debug.py
+++ b/pyx12/error_debug.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright (c) 
+# Copyright (c)
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -12,15 +12,23 @@
 Generates error debug output
 Visitor - Visits an error_handler composite
 """
+from __future__ import annotations
+from typing import Any, TextIO
 
 # Intrapackage imports
 from .error_visitor import error_visitor
+
 
 class error_debug_visitor(error_visitor):
     """
 
     """
-    def __init__(self, fd):
+
+    fd: TextIO
+    seg_count: int
+    st_control_num: int
+
+    def __init__(self, fd: TextIO) -> None:
         """
         :param fd: target file
         :type fd: file descriptor
@@ -29,21 +37,21 @@ class error_debug_visitor(error_visitor):
         self.seg_count = 0
         self.st_control_num = 0
 
-    def visit_root_pre(self, errh):
+    def visit_root_pre(self, errh: Any) -> None:
         """
         :param errh: Error_handler instance
         :type errh: L{error_handler.err_handler}
         """
         self.fd.write('%s\n' % errh.id)
 
-    def visit_root_post(self, errh):
+    def visit_root_post(self, errh: Any) -> None:
         """
         :param errh: Error_handler instance
         :type errh: L{error_handler.err_handler}
         """
         pass
 
-    def visit_isa_pre(self, err_isa):
+    def visit_isa_pre(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
@@ -58,14 +66,14 @@ class error_debug_visitor(error_visitor):
             for err in ele.errors:
                 self.fd.write('    ERR %s %s (%s)\n' % err)
 
-    def visit_isa_post(self, err_isa):
+    def visit_isa_post(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
         """
         pass
 
-    def visit_gs_pre(self, err_gs):
+    def visit_gs_pre(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -79,7 +87,7 @@ class error_debug_visitor(error_visitor):
             for err in ele.errors:
                 self.fd.write('    ERR %s %s (%s)\n' % err)
 
-    def visit_gs_post(self, err_gs):
+    def visit_gs_post(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -95,7 +103,7 @@ class error_debug_visitor(error_visitor):
         self.fd.write(' GS st_count_accept%i\n' % (
             err_gs.st_count_recv - err_gs.count_failed_st()))
 
-    def visit_st_pre(self, err_st):
+    def visit_st_pre(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
@@ -109,14 +117,14 @@ class error_debug_visitor(error_visitor):
             for err in ele.errors:
                 self.fd.write('    ERR %s %s (%s)\n' % err)
 
-    def visit_st_post(self, err_st):
+    def visit_st_post(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
         """
         pass
 
-    def visit_seg(self, err_seg):
+    def visit_seg(self, err_seg: Any) -> None:
         """
         :param err_seg: Segment error handler
         :type err_seg: L{error_handler.err_seg}
@@ -130,7 +138,7 @@ class error_debug_visitor(error_visitor):
         #for ele in err_seg.elements:
         #    self.fd.write('  %s %s\n' % (ele.id, ele.name))
 
-    def visit_ele(self, err_ele):
+    def visit_ele(self, err_ele: Any) -> None:
         """
         Params:     err_ele - error_ele instance
         :param err_ele: Element error handler

--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -10,6 +10,7 @@
 
 """
 """
+from __future__ import annotations
 
 from .errors import EngineError
 
@@ -20,11 +21,16 @@ isa_errors = ('000', '001', '002', '003', '004', '005', '006', '007', '008',
 seg_errors = ('1', '2', '3', '4', '5', '6', '7', '8')
 ele_errors = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
 
+
 class ErrorItem:
     """
     Wrap an X12 validation error
     """
-    def __init__(self, err_type, err_cde, err_str):
+
+    err_cde: str
+    err_str: str
+
+    def __init__(self, err_type: str, err_cde: str, err_str: str) -> None:
         """
         :param err_type: At what level did the error occur
         :type err_type: string
@@ -36,33 +42,50 @@ class ErrorItem:
         self.err_cde = err_cde
         self.err_str = err_str
 
-    def getErrCde(self):
+    def getErrCde(self) -> str:
         return self.err_cde
 
-    def getErrStr(self):
+    def getErrStr(self) -> str:
         return self.err_str
 
+
 class ISAError(ErrorItem):
-    def __init__(self, err_cde, err_str):
+    def __init__(self, err_cde: str, err_str: str) -> None:
         ErrorItem.__init__(self, 'isa', err_cde, err_str)
         if self.err_cde not in isa_errors:
             raise EngineError('Invalid ISA level error code "%s"' %
                               (self.err_cde))
 
+
 class SegError(ErrorItem):
-    def __init__(self, err_cde, err_str, err_val=None):
+
+    err_val: str | None
+
+    def __init__(self, err_cde: str, err_str: str, err_val: str | None = None) -> None:
         ErrorItem.__init__(self, 'seg', err_cde, err_str)
         self.err_val = err_val
         if self.err_cde not in seg_errors:
             raise EngineError('Invalid segment level error code "%s"' %
                               (self.err_cde))
 
-    def getErrVal(self):
+    def getErrVal(self) -> str | None:
         return self.err_val
 
+
 class EleError(ErrorItem):
-    def __init__(self, err_cde, err_str, ele_idx, subele_idx=None,
-                 err_val=None):
+
+    err_val: str | None
+    ele_idx: int | None
+    subele_idx: int | None
+
+    def __init__(
+        self,
+        err_cde: str,
+        err_str: str,
+        ele_idx: int | None,
+        subele_idx: int | None = None,
+        err_val: str | None = None,
+    ) -> None:
         ErrorItem.__init__(self, 'ele', err_cde, err_str)
         self.err_val = err_val
         self.ele_idx = ele_idx
@@ -71,11 +94,11 @@ class EleError(ErrorItem):
             raise EngineError('Invalid element level error code "%s"' %
                               (self.err_cde))
 
-    def getErrVal(self):
+    def getErrVal(self) -> str | None:
         return self.err_val
 
-    def getEleIdx(self):
+    def getEleIdx(self) -> int | None:
         return self.ele_idx
 
-    def getSubeleIdx(self):
+    def getSubeleIdx(self) -> int | None:
         return self.subele_idx

--- a/pyx12/error_visitor.py
+++ b/pyx12/error_visitor.py
@@ -11,65 +11,68 @@
 """
 Visitor - Visits an error_handler composite
 """
+from __future__ import annotations
+from typing import Any
+
 
 class error_visitor:
     """
     """
 
-    def __init__(self, fd):
+    def __init__(self, fd: Any) -> None:
         """
         Params:     fd - target file
         """
         pass
 
-    def visit_root_pre(self, errh):
+    def visit_root_pre(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
         """
         pass
 
-    def visit_root_post(self, errh):
+    def visit_root_post(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
         """
         pass
 
-    def visit_isa_pre(self, err_isa):
+    def visit_isa_pre(self, err_isa: Any) -> None:
         pass
 
-    def visit_isa_post(self, err_isa):
+    def visit_isa_post(self, err_isa: Any) -> None:
         """
         Params:     err_isa - error_isa instance
         """
         pass
 
-    def visit_gs_pre(self, err_gs):
+    def visit_gs_pre(self, err_gs: Any) -> None:
         pass
 
-    def visit_gs_post(self, err_gs):
+    def visit_gs_post(self, err_gs: Any) -> None:
         """
         Params:     err_gs - error_gs instance
         """
         pass
 
-    def visit_st_pre(self, err_st):
+    def visit_st_pre(self, err_st: Any) -> None:
         pass
 
-    def visit_st_post(self, err_st):
+    def visit_st_post(self, err_st: Any) -> None:
         """
         Params:     err_st - error_st instance
         """
         pass
 
-    def visit_seg(self, err_seg):
+    def visit_seg(self, err_seg: Any) -> None:
         """
         Params:     err_seg - error_seg instance
         """
         pass
 
-    def visit_ele(self, err_ele):
+    def visit_ele(self, err_ele: Any) -> None:
         """
         Params:     err_ele - error_ele instance
         """

--- a/pyx12/map_override.py
+++ b/pyx12/map_override.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -14,19 +14,30 @@ Overrides defined in a xml document.
 
 NOT IMPLEMENTED
 """
+from __future__ import annotations
+from typing import Any
+
 
 class map_override:
     """
     Apply local overrides to the current map. Overrides defined in a xml document.
     """
-    def __init__(self, map_root, override_file, icvn, vriic, fic):
+
+    def __init__(
+        self,
+        map_root: Any,
+        override_file: str,
+        icvn: str | None,
+        vriic: str | None,
+        fic: str | None,
+    ) -> None:
         pass
 
-    def _set_value(self, map_root, path, variable, value):
+    def _set_value(self, map_root: Any, path: str, variable: str, value: Any) -> None:
         pass
 
-    def _append_value(self, map_root, path, variable, value):
+    def _append_value(self, map_root: Any, path: str, variable: str, value: Any) -> None:
         pass
 
-    def _reset_list(self, map_root, path, variable, value):
+    def _reset_list(self, map_root: Any, path: str, variable: str, value: Any) -> None:
         pass

--- a/pyx12/nodeCounter.py
+++ b/pyx12/nodeCounter.py
@@ -11,15 +11,24 @@
 """
 Loop and segment counter
 """
+from __future__ import annotations
 from collections import OrderedDict
+from typing import Mapping
 import pyx12.path
 from .decorators import dump_args
+
 
 class NodeCounter:
     """
     X12 Loop and Segment Node Counter
     """
-    def __init__(self, initialCounts=None):
+
+    _dict: OrderedDict[pyx12.path.X12Path, int]
+
+    def __init__(
+        self,
+        initialCounts: Mapping[str | pyx12.path.X12Path, int] | None = None,
+    ) -> None:
         if initialCounts is None:
             initialCounts = {}
         self._dict = OrderedDict()
@@ -28,7 +37,7 @@ class NodeCounter:
             self._dict[NodeCounter.makeX12Path(k)] = v
 
     #@dump_args
-    def reset_to_node(self, xpath):
+    def reset_to_node(self, xpath: str | pyx12.path.X12Path) -> None:
         """
         Pop to node, deleting all child counts
         Keep count of xpath node
@@ -39,7 +48,7 @@ class NodeCounter:
             del self._dict[k]
 
     #@dump_args
-    def increment(self, xpath):
+    def increment(self, xpath: str | pyx12.path.X12Path) -> None:
         """
         Increment path count
         """
@@ -50,14 +59,14 @@ class NodeCounter:
             self._dict[k] = 1
 
     #@dump_args
-    def setCount(self, xpath, ct):
+    def setCount(self, xpath: str | pyx12.path.X12Path, ct: int) -> None:
         """
         Set path count
         """
         k = NodeCounter.makeX12Path(xpath)
         self._dict[k] = ct
 
-    def get_count(self, xpath):
+    def get_count(self, xpath: str | pyx12.path.X12Path) -> int:
         """
         Get path count
         """
@@ -66,11 +75,11 @@ class NodeCounter:
             return 0
         return self._dict[k]
 
-    def getState(self):
+    def getState(self) -> OrderedDict[pyx12.path.X12Path, int]:
         return self._dict
 
     @staticmethod
-    def makeX12Path(xpath):
+    def makeX12Path(xpath: str | pyx12.path.X12Path) -> pyx12.path.X12Path:
         if isinstance(xpath, pyx12.path.X12Path):
             return xpath
         else:

--- a/pyx12/xmlx12_simple.py
+++ b/pyx12/xmlx12_simple.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -10,6 +10,9 @@
 """
 Create an X12 document from a XML data file in the simple form
 """
+from __future__ import annotations
+from typing import TextIO
+from xml.etree.ElementTree import Element
 
 import defusedxml.ElementTree as et
 import logging
@@ -18,7 +21,8 @@ import logging
 import pyx12.segment
 import pyx12.x12file
 
-def convert(filename, fd_out):
+
+def convert(filename: str | TextIO, fd_out: TextIO) -> bool:
     """
     Convert a XML file in simple X12 form to an X12 file
     :param filename:  libxml2 requires a file name.  '-' gives stdin
@@ -35,7 +39,8 @@ def convert(filename, fd_out):
             wr.Write(get_segment(node))
     return True
 
-def get_segment(cSegment):
+
+def get_segment(cSegment: Element) -> pyx12.segment.Segment:
     """
     Build an X12 segment from a XML node
     """
@@ -46,10 +51,10 @@ def get_segment(cSegment):
         if node.tag == 'ele':
             ele_id = node.get('id')
             if node.text != '':
-                seg_data.set(ele_id, node.text)
+                seg_data.set(ele_id, node.text)  # type: ignore[arg-type]
         elif node.tag == 'comp':
             for subele in node.findall('subele'):
                 subele_id = subele.get('id')
                 if subele.text is not None and subele.text != '':
-                    seg_data.set(subele_id, subele.text)
+                    seg_data.set(subele_id, subele.text)  # type: ignore[arg-type]
     return seg_data


### PR DESCRIPTION
## Summary

Bundles the type-annotation pass for the seven small unhinted production modules: \`decorators.py\`, \`error_item.py\`, \`error_visitor.py\`, \`error_debug.py\`, \`nodeCounter.py\`, \`map_override.py\`, \`xmlx12_simple.py\`. Same pattern as previous typing PRs.

## Per-file notes

### [pyx12/decorators.py](pyx12/decorators.py)
- \`dump_args\` and \`memoize\` typed as \`Callable[..., Any] -> Callable[..., Any]\`. ParamSpec would be more precise but is verbose noise for these utility wrappers.
- \`memoized.__repr__\` now returns \`self.func.__doc__ or ''\` instead of the bare \`__doc__\` — bare \`__doc__\` is \`str | None\` and \`repr()\` would crash if it returned \`None\`. Latent bug fixed.

### [pyx12/error_item.py](pyx12/error_item.py)
- \`ErrorItem\` / \`ISAError\` / \`SegError\` / \`EleError\` get full signatures and class-level attribute declarations.

### [pyx12/error_visitor.py](pyx12/error_visitor.py) / [pyx12/error_debug.py](pyx12/error_debug.py)
- Visitor base class methods take \`Any\` for the \`err_*\` nodes since \`error_handler\` isn't typed yet. \`error_debug_visitor\` keeps the same signatures plus \`fd: TextIO\`.

### [pyx12/nodeCounter.py](pyx12/nodeCounter.py)
- \`_dict: OrderedDict[pyx12.path.X12Path, int]\`
- All public methods accept \`str | X12Path\` and convert via the existing \`makeX12Path\` static method.

### [pyx12/map_override.py](pyx12/map_override.py)
- Stub class (NOT IMPLEMENTED per the docstring). Annotations make the signatures explicit so mypy doesn't complain if/when it gets implemented.

### [pyx12/xmlx12_simple.py](pyx12/xmlx12_simple.py)
- \`convert(filename: str | TextIO, fd_out: TextIO) -> bool\`
- \`get_segment(cSegment: xml.etree.ElementTree.Element) -> Segment\` — defusedxml produces stdlib \`Element\` instances.

## Effect on the mypy baseline

| | Errors | Production files |
|---|---:|---:|
| Before this PR (post #99) | 904 | 16 |
| After this PR | 820 | 14 |

The -84 breaks down as:
- 62 from the 7 files in this PR
- 16 cascading on \`map_walker.py\` (50 → 34) because it imports the now-typed \`NodeCounter\`
- 6 minor cascades elsewhere

\`union-attr\` count unchanged at 41 — those genuine bugs are concentrated in the unhinted big files (\`map_if\`, \`error_handler\`, \`x12context\`).

## Latent bug fixed

\`memoized.__repr__\` returned \`self.func.__doc__\` directly. Python's \`repr()\` requires a string; a function with no docstring (the default) has \`__doc__ = None\`, which would have raised \`TypeError: __repr__ returned non-string\`. Fixed with \`or ''\`.

## Verification

- \`uv run mypy\` → 820 errors (down from 904), zero in the 7 files this PR touches
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean on all 7 files
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)