### PR TITLE
Add type hints to error-reporting family (error_html, errh_xml, error_997, error_999)

### DIFF
--- a/pyx12/errh_xml.py
+++ b/pyx12/errh_xml.py
@@ -11,6 +11,9 @@
 """
 Capture X12 Errors
 """
+from __future__ import annotations
+from types import TracebackType
+from typing import IO, Any, Literal
 
 import logging
 import tempfile
@@ -20,11 +23,23 @@ import os
 from .errors import EngineError
 from .xmlwriter import XMLWriter
 
+# (kind, code, message, value, src_line)
+_ErrTuple = tuple[str, str, str, Any, int | None]
+
+
 class err_handler:
     """
     The interface to the error handling structures.
     """
-    def __init__(self, xml_out=None, basedir=None):
+
+    logger: logging.Logger
+    filename: str
+    fd: IO[Any]
+    cur_line: int | None
+    errors: list[_ErrTuple]
+    writer: XMLWriter
+
+    def __init__(self, xml_out: str | None = None, basedir: str | None = None) -> None:
         """
         :param xml_out: Output filename, if None, will dump to tempfile
         :param basedir: working directory, where file will be created
@@ -47,7 +62,7 @@ class err_handler:
         self.writer = XMLWriter(self.fd)
         self.writer.push("x12err")
 
-    def close(self):
+    def close(self) -> None:
         """
         Flush remaining XML closing tags and close the underlying file.
         Idempotent.
@@ -57,17 +72,22 @@ class err_handler:
         if self.fd is not None and not self.fd.closed:
             self.fd.close()
 
-    def __enter__(self):
+    def __enter__(self) -> err_handler:
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         self.close()
         return False
 
-    def getFilename(self):
+    def getFilename(self) -> str:
         return self.filename
 
-    def handleErrors(self, err_list):
+    def handleErrors(self, err_list: list[_ErrTuple]) -> None:
         """
         :param err_list: list of errors to apply
         """
@@ -82,14 +102,14 @@ class err_handler:
         #    elif err_type == 'seg':
         #        self.seg_error(err_cde, err_str, err_val, src_line)
 
-    def getCurLine(self):
+    def getCurLine(self) -> int | None:
         """
         :return: Current file line number
         :rtype: int
         """
         return self.cur_line
 
-    def Write(self, cur_line):
+    def Write(self, cur_line: int) -> None:
         """
         Generate XML for the segment data and matching map node
 
@@ -111,15 +131,22 @@ class err_handler:
             self.writer.pop()  # end segment
             self.errors = []
 
+
 class ErrorErrhNull(Exception):
     """Class for errh_null errors."""
+
 
 class errh_list:
     """
     A null error object - used for testing.
     Stores the current error in simple variables.
     """
-    def __init__(self):
+
+    logger: logging.Logger
+    errors: list[_ErrTuple]
+    cur_line: int
+
+    def __init__(self) -> None:
         self.logger = logging.getLogger('pyx12.errh_xml')
         #self.id = 'ROOT'
         self.errors = []
@@ -128,20 +155,20 @@ class errh_list:
         #self.err_cde = None
         #self.err_str = None
 
-    def get_errors(self):
+    def get_errors(self) -> list[_ErrTuple]:
         return self.errors
 
-    def reset(self):
+    def reset(self) -> None:
         self.errors = []
 
-    def get_cur_line(self):
+    def get_cur_line(self) -> int:
         """
         :return: Current file line number
         :rtype: int
         """
         return self.cur_line
 
-    def set_cur_line(self, cur_line):
+    def set_cur_line(self, cur_line: int) -> None:
         """
         """
         self.cur_line = cur_line
@@ -153,33 +180,33 @@ class errh_list:
 #        """
 #        return self.id
 
-    def add_isa_loop(self, seg, src):
+    def add_isa_loop(self, seg: Any, src: Any) -> None:
         """
         """
         #raise ErrorErrhNull, 'add_isa loop'
         pass
 
-    def add_gs_loop(self, seg, src):
+    def add_gs_loop(self, seg: Any, src: Any) -> None:
         """
         """
         pass
 
-    def add_st_loop(self, seg, src):
+    def add_st_loop(self, seg: Any, src: Any) -> None:
         """
         """
         pass
 
-    def add_seg(self, map_node, seg, seg_count, cur_line, ls_id):
+    def add_seg(self, map_node: Any, seg: Any, seg_count: int, cur_line: int, ls_id: str | None) -> None:
         """
         """
         pass
 
-    def add_ele(self, map_node):
+    def add_ele(self, map_node: Any) -> None:
         """
         """
         pass
 
-    def isa_error(self, err_cde, err_str):
+    def isa_error(self, err_cde: str, err_str: str) -> None:
         """
         :param err_cde: ISA level error code
         :type err_cde: string
@@ -192,7 +219,7 @@ class errh_list:
         sout += 'ISA:%s - %s' % (err_cde, err_str)
         self.logger.error(sout)
 
-    def gs_error(self, err_cde, err_str):
+    def gs_error(self, err_cde: str, err_str: str) -> None:
         """
         :param err_cde: GS level error code
         :type err_cde: string
@@ -205,7 +232,7 @@ class errh_list:
         sout += 'GS:%s - %s' % (err_cde, err_str)
         self.logger.error(sout)
 
-    def st_error(self, err_cde, err_str):
+    def st_error(self, err_cde: str, err_str: str) -> None:
         """
         :param err_cde: Segment level error code
         :type err_cde: string
@@ -218,7 +245,13 @@ class errh_list:
         sout += 'ST:%s - %s' % (err_cde, err_str)
         self.logger.error(sout)
 
-    def seg_error(self, err_cde, err_str, err_value=None, src_line=None):
+    def seg_error(
+        self,
+        err_cde: str,
+        err_str: str,
+        err_value: str | None = None,
+        src_line: int | None = None,
+    ) -> None:
         """
         :param err_cde: Segment level error code
         :type err_cde: string
@@ -233,7 +266,7 @@ class errh_list:
             sout += ' (%s)' % err_value
         self.logger.error(sout)
 
-    def ele_error(self, err_cde, err_str, bad_value):
+    def ele_error(self, err_cde: str, err_str: str, bad_value: str | None) -> None:
         """
         :param err_cde: Element level error code
         :type err_cde: string
@@ -248,28 +281,28 @@ class errh_list:
             sout += ' (%s)' % (bad_value)
         self.logger.error(sout)
 
-    def close_isa_loop(self, node, seg, src):
+    def close_isa_loop(self, node: Any, seg: Any, src: Any) -> None:
         """
         """
         pass
 
-    def close_gs_loop(self, node, seg, src):
+    def close_gs_loop(self, node: Any, seg: Any, src: Any) -> None:
         """
         """
         pass
 
-    def close_st_loop(self, node, seg, src):
+    def close_st_loop(self, node: Any, seg: Any, src: Any) -> None:
         """
         """
         pass
 
-    def find_node(self, atype):
+    def find_node(self, atype: str) -> None:
         """
         Find the last node of a type
         """
         pass
 
-    def get_parent(self):
+    def get_parent(self) -> None:
         return None
 
 #    def get_first_child(self):
@@ -280,17 +313,17 @@ class errh_list:
 #        else:
 #            return None
 
-    def get_next_sibling(self):
+    def get_next_sibling(self) -> None:
         """
         """
         return None
 
-    def get_error_count(self):
+    def get_error_count(self) -> int:
         """
         """
         return len(self.errors)
 
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """
         :rtype: boolean
         """

--- a/pyx12/error_997.py
+++ b/pyx12/error_997.py
@@ -12,6 +12,8 @@
 Generates a 997 Response
 Visitor - Visits an error_handler composite
 """
+from __future__ import annotations
+from typing import Any, TextIO
 
 import time
 import logging
@@ -24,11 +26,27 @@ import pyx12.segment
 logger = logging.getLogger('pyx12.error_997')
 logger.setLevel(logging.DEBUG)
 
+
 class error_997_visitor(error_visitor.error_visitor):
     """
     Visit an error_handler composite.  Generate a 997.
     """
-    def __init__(self, fd, term=('~', '*', '~', '\n')):
+
+    fd: TextIO
+    seg_term: str
+    ele_term: str
+    subele_term: str
+    eol: str
+    seg_count: int
+    isa_control_num: str | None
+    isa_seg: pyx12.segment.Segment | None
+    gs_loop_count: int
+    gs_id: str | None
+    gs_seg: pyx12.segment.Segment | None
+    st_control_num: int
+    st_loop_count: int
+
+    def __init__(self, fd: TextIO, term: tuple[str, str, str, str] = ('~', '*', '~', '\n')) -> None:
         """
         :param fd: target file
         :type fd: file descriptor
@@ -53,7 +71,7 @@ class error_997_visitor(error_visitor.error_visitor):
         self.st_control_num = 0
         self.st_loop_count = 0
 
-    def visit_root_pre(self, errh):
+    def visit_root_pre(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
@@ -100,7 +118,7 @@ class error_997_visitor(error_visitor.error_visitor):
         self.st_loop_count = 0
         self.gs_loop_count += 1
 
-    def __get_isa_errors(self, err_isa):
+    def __get_isa_errors(self, err_isa: Any) -> list[str]:
         """
         Build list of TA1 level errors
         Only the first error is used
@@ -128,7 +146,7 @@ class error_997_visitor(error_visitor.error_visitor):
 
         # return unique codes, while trying to keep the order of the list
         # this is to ensure that test result is deterministic on Python 3
-        uniq_codes = []
+        uniq_codes: list[str] = []
         for err in err_codes:
             if err in uniq_codes:
                 continue
@@ -141,13 +159,14 @@ class error_997_visitor(error_visitor.error_visitor):
 
         return uniq_codes
 
-    def visit_root_post(self, errh):
+    def visit_root_post(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
         """
-        self._write(pyx12.segment.Segment('GE*%i*%s' % (self.st_loop_count,
-                                                        self.gs_seg.get_value('GS06')), '~', '*', ':'))
+        gs06 = self.gs_seg.get_value('GS06') if self.gs_seg is not None else ''
+        self._write(pyx12.segment.Segment('GE*%i*%s' % (self.st_loop_count, gs06),
+                                          '~', '*', ':'))
         self.gs_loop_count = 1
 
         #pdb.set_trace()
@@ -173,19 +192,19 @@ class error_997_visitor(error_visitor.error_visitor):
         self._write(pyx12.segment.Segment('IEA*%i*%s' %
                                           (self.gs_loop_count, self.isa_control_num), '~', '*', ':'))
 
-    def visit_isa_pre(self, err_isa):
+    def visit_isa_pre(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
         """
 
-    def visit_isa_post(self, err_isa):
+    def visit_isa_post(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
         """
 
-    def visit_gs_pre(self, err_gs):
+    def visit_gs_pre(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -206,7 +225,7 @@ class error_997_visitor(error_visitor.error_visitor):
         self._write(pyx12.segment.Segment('AK1*%s*%s' %
                                           (err_gs.fic, err_gs.gs_control_num), '~', '*', ':'))
 
-    def __get_gs_errors(self, err_gs):
+    def __get_gs_errors(self, err_gs: Any) -> list[str]:
         """
         Build list of GS level errors
         """
@@ -232,7 +251,7 @@ class error_997_visitor(error_visitor.error_visitor):
         ret.sort()
         return ret
 
-    def visit_gs_post(self, err_gs):
+    def visit_gs_post(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -286,7 +305,7 @@ class error_997_visitor(error_visitor.error_visitor):
         #seg = ['SE', '%i' % seg_count, '%04i' % self.st_control_num]
         self._write(seg_data)
 
-    def visit_st_pre(self, err_st):
+    def visit_st_pre(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
@@ -296,7 +315,7 @@ class error_997_visitor(error_visitor.error_visitor):
         seg_data.append(err_st.trn_set_control_num.strip())
         self._write(seg_data)
 
-    def __get_st_errors(self, err_st):
+    def __get_st_errors(self, err_st: Any) -> list[str]:
         """
         Build list of ST level errors
         """
@@ -317,7 +336,7 @@ class error_997_visitor(error_visitor.error_visitor):
         ret.sort()
         return ret
 
-    def visit_st_post(self, err_st):
+    def visit_st_post(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
@@ -335,7 +354,7 @@ class error_997_visitor(error_visitor.error_visitor):
             #seg.append(err_codes[i])
         self._write(seg_data)
 
-    def visit_seg(self, err_seg):
+    def visit_seg(self, err_seg: Any) -> None:
         """
         :param err_seg: Segment error handler
         :type err_seg: L{error_handler.err_seg}
@@ -366,7 +385,7 @@ class error_997_visitor(error_visitor.error_visitor):
             seg_data.set('AK304', '8')
             self._write(seg_data)
 
-    def visit_ele(self, err_ele):
+    def visit_ele(self, err_ele: Any) -> None:
         """
         :param err_ele: Segment error handler
         :type err_ele: L{error_handler.err_ele}
@@ -390,7 +409,7 @@ class error_997_visitor(error_visitor.error_visitor):
                     seg_data.set('AK404', bad_value)
                 self._write(seg_data)
 
-    def _write(self, seg_data):
+    def _write(self, seg_data: pyx12.segment.Segment) -> None:
         """
         Params:     seg_data -
         :param seg_data: Data segment instance

--- a/pyx12/error_999.py
+++ b/pyx12/error_999.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -12,6 +12,8 @@
 Generates a 999 Response
 Visitor - Visits an error_handler composite
 """
+from __future__ import annotations
+from typing import Any, TextIO
 
 import time
 import logging
@@ -26,11 +28,29 @@ import pyx12.x12file
 logger = logging.getLogger('pyx12.error_999')
 logger.setLevel(logging.DEBUG)
 
+
 class error_999_visitor(pyx12.error_visitor.error_visitor):
     """
     Visit an error_handler composite.  Generate a 999.
     """
-    def __init__(self, fd, term=('~', '*', ':', '\n', '^')):
+
+    fd: TextIO
+    wr: pyx12.x12file.X12Writer
+    seg_term: str
+    ele_term: str
+    subele_term: str
+    repetition_term: str
+    eol: str
+    isa_control_num: str | None
+    gs_control_num: str | None
+    st_control_num: int
+    vriic: str
+
+    def __init__(
+        self,
+        fd: TextIO,
+        term: tuple[str, str, str, str, str] = ('~', '*', ':', '\n', '^'),
+    ) -> None:
         """
         :param fd: target file
         :type fd: file descriptor
@@ -49,7 +69,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         self.st_control_num = 0
         self.vriic = '005010X231'
 
-    def visit_root_pre(self, errh):
+    def visit_root_pre(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
@@ -93,7 +113,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         gs_seg.set('08', self.vriic)
         self.wr.Write(gs_seg)
 
-    def __get_isa_errors(self, err_isa):
+    def __get_isa_errors(self, err_isa: Any) -> list[str]:
         """
         Build list of TA1 level errors
         Only the first error is used
@@ -114,7 +134,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         # return unique codes
         return list(set(err_codes))
 
-    def visit_root_post(self, errh):
+    def visit_root_post(self, errh: Any) -> None:
         """
         :param errh: Error handler
         :type errh: L{error_handler.err_handler}
@@ -143,20 +163,20 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
             self.wr.Write(ta1_seg)
         self.wr.Write(pyx12.segment.Segment('IEA', '~', '*', ':'))
 
-    def visit_isa_pre(self, err_isa):
+    def visit_isa_pre(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
         """
 
-    def visit_isa_post(self, err_isa):
+    def visit_isa_post(self, err_isa: Any) -> None:
         """
         :param err_isa: ISA Loop error handler
         :type err_isa: L{error_handler.err_isa}
         """
         pass
 
-    def visit_gs_pre(self, err_gs):
+    def visit_gs_pre(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -173,7 +193,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         ak1.set('03', err_gs.vriic)
         self.wr.Write(ak1)
 
-    def __get_gs_errors(self, err_gs):
+    def __get_gs_errors(self, err_gs: Any) -> list[str]:
         """
         Build list of GS level errors
         """
@@ -198,7 +218,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         ret.sort()
         return ret
 
-    def visit_gs_post(self, err_gs):
+    def visit_gs_post(self, err_gs: Any) -> None:
         """
         :param err_gs: GS Loop error handler
         :type err_gs: L{error_handler.err_gs}
@@ -229,7 +249,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         seg_data.append('%04i' % self.st_control_num)
         self.wr.Write(seg_data)
 
-    def visit_st_pre(self, err_st):
+    def visit_st_pre(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
@@ -248,7 +268,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         seg_data.set('03', err_st.vriic)
         self.wr.Write(seg_data)
 
-    def __get_st_errors(self, err_st):
+    def __get_st_errors(self, err_st: Any) -> list[str]:
         """
         Build list of ST level errors
         """
@@ -269,7 +289,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         ret.sort()
         return ret
 
-    def visit_st_post(self, err_st):
+    def visit_st_post(self, err_st: Any) -> None:
         """
         :param err_st: ST Loop error handler
         :type err_st: L{error_handler.err_st}
@@ -283,7 +303,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
             seg_data.append(err_code)
         self.wr.Write(seg_data)
 
-    def visit_seg(self, err_seg):
+    def visit_seg(self, err_seg: Any) -> None:
         """
         :param err_seg: Segment error handler
         :type err_seg: L{error_handler.err_seg}
@@ -314,7 +334,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
             seg_data.set('IK304', '8')
             self.wr.Write(seg_data)
 
-    def visit_ele(self, err_ele):
+    def visit_ele(self, err_ele: Any) -> None:
         """
         :param err_ele: Segment error handler
         :type err_ele: L{error_handler.err_ele}

--- a/pyx12/error_html.py
+++ b/pyx12/error_html.py
@@ -11,21 +11,40 @@
 """
 Generates HTML error output
 """
+from __future__ import annotations
+from typing import Any, TextIO
 
 import html
 import time
 import logging
 
 # Intrapackage imports
+import pyx12.segment
 
 logger = logging.getLogger('pyx12.error_html')
 logger.setLevel(logging.DEBUG)
 #logger.setLevel(logging.ERROR)
 
+
 class error_html:
     """
     """
-    def __init__(self, errh, fd, term=('~', '*', '~', '\n')):
+
+    errh: Any
+    fd: TextIO
+    seg_term: str
+    ele_term: str
+    subele_term: str
+    eol: str
+    last_line: int
+    loop_info: str | None
+
+    def __init__(
+        self,
+        errh: Any,
+        fd: TextIO,
+        term: tuple[str, str, str, str] | tuple[str, str, str, str, str | None] = ('~', '*', '~', '\n'),
+    ) -> None:
         """
         :param fd: target file
         :type fd: file descriptor
@@ -43,7 +62,7 @@ class error_html:
         self.last_line = 0
         self.loop_info = None
 
-    def header(self):
+    def header(self) -> None:
         self.fd.write('<html>\n<head>\n')
         self.fd.write('<title>X12N Error Analysis</title>\n')
         self.fd.write('<style type="text/css">\n<!--\n')
@@ -58,7 +77,7 @@ class error_html:
                       (time.strftime('%m/%d/%Y %H:%M:%S')))
         self.fd.write('<div class="segs" style="">\n')
 
-    def footer(self):
+    def footer(self) -> None:
         err_st = self.errh.cur_st_node
         if not err_st.is_closed():
             for (err_cde, err_str) in err_st.errors:
@@ -81,18 +100,18 @@ class error_html:
         self.fd.write('<p>\n<a href="http://sourceforge.net/projects/pyx12/">pyx12 Validator</a>\n</p>\n')
         self.fd.write('</body>\n</html>\n')
 
-    def loop(self, loop_node):
+    def loop(self, loop_node: Any) -> None:
         if loop_node.type != 'wrapper':
             #self.gen_info('Loop %s: %s' % (loop_node.id, loop_node.name))
             self.loop_info = 'Loop %s: %s' % (loop_node.id, loop_node.name)
 
-    def gen_info(self, info_str):
+    def gen_info(self, info_str: str) -> None:
         """
         """
         self.fd.write('<span class="info">&nbsp;&nbsp;%s</span><br />\n' %
                       (info_str))
 
-    def gen_seg(self, seg_data, src, err_node_list):
+    def gen_seg(self, seg_data: pyx12.segment.Segment, src: Any, err_node_list: list[Any]) -> None:
         """
         Find error seg for this segment.
         Find any skipped error values.
@@ -102,12 +121,12 @@ class error_html:
         cur_line = src.cur_line
 
         #while errh
-        ele_pos_map = {}
+        ele_pos_map: dict[int, int] = {}
         for err_node in err_node_list:
             for ele in err_node.elements:
                 ele_pos_map[ele.ele_pos] = ele.subele_pos
 
-        t_seg = []  # list of formatted elements
+        t_seg: list[Any] = []  # list of formatted elements
         #seg_data.format_ele_list(t_seg)
         for i in range(1, len(seg_data) + 1):
             if seg_data.is_composite(ref_des='%02i' % (i)):
@@ -154,22 +173,29 @@ class error_html:
                         self.fd.write('<span class="error">&nbsp;%s (Element Error Code: %s)</span><br />\n' %
                                       (err_str, err_cde))
 
-    def _seg_str(self, seg_id, ele_list):
+    def _seg_str(self, seg_id: str | None, ele_list: list[Any]) -> str:
         """
         :param ele_list: list of formatted elements
         :rtype: string
         """
-        return seg_id + self.ele_term + seg_str(
+        return (seg_id or '') + self.ele_term + seg_str(
             ele_list, self.seg_term, self.ele_term,
             self.subele_term, self.eol)
 
-    def _wrap_ele_error(self, str1):
+    def _wrap_ele_error(self, str1: str | None) -> str:
         """
         :rtype: string
         """
         return '<span class="ele_err">%s</span>' % (str1)
 
-def seg_str(seg, seg_term, ele_term, subele_term, eol=''):
+
+def seg_str(
+    seg: list[Any],
+    seg_term: str,
+    ele_term: str,
+    subele_term: str,
+    eol: str = '',
+) -> str:
     """
     Join a list of elements
     :param seg: List of elements
@@ -187,7 +213,7 @@ def seg_str(seg, seg_term, ele_term, subele_term, eol=''):
     """
     #if None in seg:
     #    logger.debug(seg)
-    tmp = []
+    tmp: list[str] = []
     for a in seg:
         if type(a) is list:
             tmp.append(subele_term.join(a))
@@ -195,7 +221,8 @@ def seg_str(seg, seg_term, ele_term, subele_term, eol=''):
             tmp.append(a)
     return '%s%s%s' % (ele_term.join(tmp), seg_term, eol)
 
-def escape_html_chars(str_val):
+
+def escape_html_chars(str_val: str | None) -> str | None:
     """
     Escape special HTML characters, including quotes, so the result is safe in
     both element text and attribute contexts. Spaces are replaced with &nbsp;


### PR DESCRIPTION
## Summary

Bundles the type-annotation pass for the four error-reporting modules:

- \`error_html.py\` — HTML error report renderer
- \`errh_xml.py\` — XML error capture (\`err_handler\` + \`errh_list\`)
- \`error_997.py\` — 997 acknowledgement visitor (4010)
- \`error_999.py\` — 999 acknowledgement visitor (5010)

Same pattern as previous typing PRs. The visitor classes accept \`Any\` for the error-tree nodes since \`error_handler\` itself is not yet typed (saved for the big-tier PR).

## Per-file notes

### [pyx12/error_html.py](pyx12/error_html.py)
- \`error_html\` class typed; \`fd: TextIO\`, \`errh: Any\`, terminators as \`str\`.
- \`gen_seg\` takes \`seg_data: pyx12.segment.Segment\` and \`src/err_node_list: Any\`.
- \`_seg_str\` now safely handles \`seg_id is None\` via \`(seg_id or '')\`.
- Module-level \`seg_str\` and \`escape_html_chars\` get full signatures.

### [pyx12/errh_xml.py](pyx12/errh_xml.py)
- \`err_handler\` and \`errh_list\` get full class-level attribute declarations.
- Shared \`_ErrTuple = tuple[str, str, str, Any, int | None]\` matching x12file.py's shape.
- \`err_handler.__exit__ -> Literal[False]\` (matches X12Reader/Writer).
- \`err_handler.fd: IO[Any]\` because the XML error file may be opened in text or binary mode (same pattern as map_index.py / codes.py / dataele.py).

### [pyx12/error_997.py](pyx12/error_997.py) / [pyx12/error_999.py](pyx12/error_999.py)
- \`error_997_visitor\` / \`error_999_visitor\`: full class-level attribute declarations covering control numbers, terminator strings, segment refs, and (999) the wrapped \`X12Writer\`.
- All \`visit_*\` methods take \`Any\` for the error-tree nodes.
- Internal \`__get_*_errors\` helpers return \`list[str]\`.

## Latent bug fix (error_997.py)

\`visit_root_post\` accessed \`self.gs_seg.get_value('GS06')\` unconditionally. \`gs_seg\` is initialized to \`None\` in \`__init__\` and populated only by \`visit_root_pre\`. If \`visit_root_post\` ever fired without \`visit_root_pre\` (or after a partial run), this was an \`AttributeError\` waiting to happen. Now guards with \`self.gs_seg is not None\`. Low-risk in practice but cleaner.

## Effect on mypy baseline

| | Errors | Production files |
|---|---:|---:|
| Before (post #100) | 820 | 14 |
| After this PR | 714 | 9 |

Of the -106:
\`\`\`
errh_xml      34 -> 0
error_997     34 -> 0
error_999     18 -> 0
error_html    18 -> 0
              ---
              104 directly + 2 small cascades elsewhere
\`\`\`

The remaining 9 production files: map_if (212), error_handler (194), x12context (120), x12n_document (42), x12xml (38), x12metadata (37), map_walker (34), x12xml_simple (21), segment/dataele (~5 residual cascade).

## Verification

- \`uv run mypy\` → 714 errors (down from 820)
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean on all 4 files
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)