### PR TITLE
Add type hints to medium-tier modules

### DIFF
--- a/pyx12/map_walker.py
+++ b/pyx12/map_walker.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright (c) 2001-2013 
+# Copyright (c) 2001-2013
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -14,11 +14,14 @@ Walk a tree of x12_map nodes.  Find the correct node.
 If seg indicates a loop has been entered, returns the first child segment node.
 If seg indicates a segment has been entered, returns the segment node.
 """
+from __future__ import annotations
+from typing import Any, Mapping
 
 import logging
 
 # Intrapackage imports
 from .errors import EngineError
+import pyx12.path
 import pyx12.segment
 from .nodeCounter import NodeCounter
 
@@ -26,7 +29,8 @@ logger = logging.getLogger('pyx12.walk_tree')
 #logger.setLevel(logging.DEBUG)
 #logger.setLevel(logging.ERROR)
 
-def pop_to_parent_loop(node):
+
+def pop_to_parent_loop(node: Any) -> Any:
     """
     :param node: Loop Node
     :type node: L{node<map_if.x12_node>}
@@ -44,7 +48,8 @@ def pop_to_parent_loop(node):
         raise EngineError("Called pop_to_parent_loop, can't find parent loop")
     return map_node
 
-def is_first_seg_match2(child, seg_data):
+
+def is_first_seg_match2(child: Any, seg_data: pyx12.segment.Segment) -> bool:
     """
     Find the first segment in loop, verify it matches segment
 
@@ -62,15 +67,17 @@ def is_first_seg_match2(child, seg_data):
             return False
     return False
 
-def get_id_list(node_list):
+
+def get_id_list(node_list: list[Any]) -> list[str]:
     # get_id_list(pop)
-    ret = []
+    ret: list[str] = []
     for node in node_list:
         if node is not None:
             ret.append(node.id)
     return ret
 
-def traverse_path(start_node, pop_loops, push_loops):
+
+def traverse_path(start_node: Any, pop_loops: list[Any], push_loops: list[Any]) -> str:
     """
     Debug function - From the start path, pop up then push down to get a path string
     """
@@ -84,18 +91,34 @@ def traverse_path(start_node, pop_loops, push_loops):
         p1.append(loop_id)
     return '/' + '/'.join(p1)
 
+
 class walk_tree:
     """
     Walks a map_if tree.  Tracks loop/segment counting, missing loop/segment.
     """
-    def __init__(self, initialCounts=None):
+
+    mandatory_segs_missing: list[tuple[Any, pyx12.segment.Segment, str, str, int, int, str | None]]
+    counter: NodeCounter
+
+    def __init__(
+        self,
+        initialCounts: Mapping[str | pyx12.path.X12Path, int] | None = None,
+    ) -> None:
         # Store errors until we know we have an error
         self.mandatory_segs_missing = []
         if initialCounts is None:
             initialCounts = {}
         self.counter = NodeCounter(initialCounts)
 
-    def walk(self, node, seg_data, errh, seg_count, cur_line, ls_id):
+    def walk(
+        self,
+        node: Any,
+        seg_data: pyx12.segment.Segment,
+        errh: Any,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+    ) -> tuple[Any, list[Any], list[Any]]:
         """
         Walk the node tree from the starting node to the node matching
         seg_data. Catch any counting or requirement errors along the way.
@@ -119,8 +142,8 @@ class walk_tree:
 
         TODO: check single segment loop repeat
         """
-        pop_node_list = []
-        push_node_list = []
+        pop_node_list: list[Any] = []
+        push_node_list: list[Any] = []
         orig_node = node
         #logger.info('%s seg_count=%i / cur_line=%i' % (node.id, seg_count, cur_line))
         self.mandatory_segs_missing = []
@@ -182,19 +205,29 @@ class walk_tree:
         walk_tree._seg_not_found_error(orig_node, seg_data, errh, seg_count, cur_line, ls_id)
         return (None, [], [])
 
-    def getCountState(self):
+    def getCountState(self) -> Any:
         return self.counter.getState()
 
-    def setCountState(self, initialCounts={}):
+    def setCountState(self, initialCounts: Mapping[str | pyx12.path.X12Path, int] | None = None) -> None:
+        if initialCounts is None:
+            initialCounts = {}
         self.counter = NodeCounter(initialCounts)
 
-    def forceWalkCounterToLoopStart(self, x12_path, child_path):
+    def forceWalkCounterToLoopStart(self, x12_path: str, child_path: str) -> None:
         # delete child counts under the x12_path, no longer needed
         self.counter.reset_to_node(x12_path)
         self.counter.increment(x12_path)  # add a count for this path
         self.counter.increment(child_path) # count the loop start segment
 
-    def _check_seg_usage(self, seg_node, seg_data, seg_count, cur_line, ls_id, errh):
+    def _check_seg_usage(
+        self,
+        seg_node: Any,
+        seg_data: pyx12.segment.Segment,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+        errh: Any,
+    ) -> None:
         """
         Check segment usage requirement and count
 
@@ -226,7 +259,14 @@ class walk_tree:
                 errh.seg_error('5', err_str, None)
 
     @staticmethod
-    def _seg_not_found_error(orig_node, seg_data, errh, seg_count, cur_line, ls_id):
+    def _seg_not_found_error(
+        orig_node: Any,
+        seg_data: pyx12.segment.Segment,
+        errh: Any,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+    ) -> None:
         """
         Create error for not found segments
 
@@ -245,7 +285,7 @@ class walk_tree:
         errh.add_seg(orig_node, seg_data, seg_count, cur_line, ls_id)
         errh.seg_error('1', err_str, None)
 
-    def _flush_mandatory_segs(self, errh, cur_pos=None):
+    def _flush_mandatory_segs(self, errh: Any, cur_pos: int | None = None) -> None:
         """
         Handle error reporting for any outstanding missing mandatory segments
 
@@ -259,7 +299,15 @@ class walk_tree:
                 errh.seg_error(err_cde, err_str, None)
         self.mandatory_segs_missing = [x for x in self.mandatory_segs_missing if x[0].pos == cur_pos]
 
-    def _is_loop_match(self, loop_node, seg_data, errh, seg_count, cur_line, ls_id):
+    def _is_loop_match(
+        self,
+        loop_node: Any,
+        seg_data: pyx12.segment.Segment,
+        errh: Any,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+    ) -> bool:
         """
         Try to match the current loop to the segment
         Handle loop and segment counting.
@@ -304,7 +352,15 @@ class walk_tree:
                                                 '3', err_str, seg_count, cur_line, ls_id))
         return False
 
-    def _goto_seg_match(self, loop_node, seg_data, errh, seg_count, cur_line, ls_id):
+    def _goto_seg_match(
+        self,
+        loop_node: Any,
+        seg_data: pyx12.segment.Segment,
+        errh: Any,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+    ) -> tuple[Any, list[Any]]:
         """
         A child loop has matched the segment.  Return that segment node.
         Handle loop counting and requirement errors.
@@ -348,7 +404,15 @@ class walk_tree:
                         return (node1, push_node_list)
         return (None, [])
 
-    def _check_loop_usage(self, loop_node, seg_data, seg_count, cur_line, ls_id, errh):
+    def _check_loop_usage(
+        self,
+        loop_node: Any,
+        seg_data: pyx12.segment.Segment,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+        errh: Any,
+    ) -> None:
         """
         Check loop usage requirement and count
 

--- a/pyx12/x12metadata.py
+++ b/pyx12/x12metadata.py
@@ -1,11 +1,7 @@
-import sys
-import os
-import os.path
-import logging
+from __future__ import annotations
+from typing import Any, TextIO
 
-libpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
-if os.path.isdir(libpath):
-    sys.path.insert(0, libpath)
+import logging
 
 # Intrapackage imports
 import pyx12.error_handler
@@ -16,7 +12,13 @@ import pyx12.params
 import pyx12.x12file
 from pyx12.map_walker import walk_tree
 
-def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
+
+def get_x12file_metadata(
+    param: pyx12.params.ParamsBase,
+    src_file: str | TextIO,
+    map_path: str | None = None,
+    do_node_summary: bool = False,
+) -> tuple[bool, dict[str, Any] | None, dict[str, Any] | None]:
     logger = logging.getLogger('pyx12')
     errh = pyx12.error_handler.errh_null()
 
@@ -34,14 +36,18 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
     map_index_if = pyx12.map_index.map_index(map_path)
     node = control_map.getnodebypath('/ISA_LOOP/ISA')
     walker = walk_tree()
-    icvn = fic = vriic = tspc = None
-    cur_map = None  # we do not initially know the X12 transaction type
+    icvn: str | None = None
+    fic: str | None = None
+    vriic: str | None = None
+    tspc: str | None = None
+    cur_map: Any = None  # we do not initially know the X12 transaction type
 
-    isa_data = {}
+    isa_data: dict[str, Any] = {}
+    node_summary: dict[str, Any] | None
+    node_ordinal = 0
+    last_x12_segment_path: str | None = None
     if do_node_summary:
         node_summary = {}
-        node_ordinal = 0
-        last_x12_segment_path = None
     else:
         node_summary = None
     for seg in src:
@@ -62,8 +68,7 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
                 raise
         if node is None:
             raise pyx12.errors.EngineError("Node not found")
-            node = orig_node
-        
+
         if seg.get_seg_id() == 'ISA':
             icvn = seg.get_value('ISA12')
         elif seg.get_seg_id() == 'IEA':
@@ -81,7 +86,6 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
                 src.check_837_lx = True if cur_map.id == '837' else False
                 logger.debug('Map file: %s' % (map_file))
             node = cur_map.getnodebypath('/ISA_LOOP/GS_LOOP/GS')
-            pass
         elif seg.get_seg_id() == 'BHT':
             # special case for 4010 837P
             if vriic in ('004010X094', '004010X094A1'):
@@ -153,7 +157,7 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
 
         x12path = node.get_path()
         #parent
-        if do_node_summary:
+        if do_node_summary and node_summary is not None:
             if x12path in node_summary:
                 node_summary[x12path]['Count'] += 1
                 if last_x12_segment_path not in node_summary[x12path]['prefix_nodes']:
@@ -171,7 +175,7 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
                     'prefix_nodes': [last_x12_segment_path]
                 }
                 node_ordinal += 1
-            
+
             for (refdes, ele_ord, comp_ord, val) in seg.values_iterator():
                 ele_node = node.getnodebypath2(refdes)
                 if ele_node.is_composite():
@@ -199,7 +203,12 @@ def get_x12file_metadata(param, src_file, map_path=None, do_node_summary=False):
     src.close()
     return (True, isa_data, node_summary)
 
-def get_x12file_metadata_headers(param, src_file, map_path=None):
+
+def get_x12file_metadata_headers(
+    param: pyx12.params.ParamsBase,
+    src_file: str | TextIO,
+    map_path: str | None = None,
+) -> tuple[bool, dict[str, Any] | None]:
     logger = logging.getLogger('pyx12')
     errh = pyx12.error_handler.errh_null()
 
@@ -209,7 +218,7 @@ def get_x12file_metadata_headers(param, src_file, map_path=None):
     except pyx12.errors.X12Error:
         logger.error('"%s" does not look like an X12 data file' % (src_file))
         return (False, None)
-    isa_data = None
+    isa_data: dict[str, Any] | None = None
     for seg in src:
         if seg.get_seg_id() == 'ISA':
             isa_data = {
@@ -227,7 +236,7 @@ def get_x12file_metadata_headers(param, src_file, map_path=None):
                 'GSLoops': []
                 }
             icvn = isa_data['InterchangeControlVersionNumber']
-        elif seg.get_seg_id() == 'IEA':
+        elif seg.get_seg_id() == 'IEA' and isa_data is not None:
             isa_data['NumberofIncludedFunctionalGroups'] = seg.get_value('IEA01')
         elif seg.get_seg_id() == 'GS':
             gs_data = {
@@ -241,7 +250,7 @@ def get_x12file_metadata_headers(param, src_file, map_path=None):
                 'VersionReleaseIndustryIdentifierCode': seg.get_value('GS08'),
                 'STLoops': []
                 }
-        elif seg.get_seg_id() == 'GE':
+        elif seg.get_seg_id() == 'GE' and isa_data is not None:
             gs_data['NumberofTransactionSetsIncluded'] = seg.get_value('GE01')
             isa_data['GSLoops'].append(gs_data)
         elif seg.get_seg_id() == 'ST':

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -12,6 +12,9 @@
 Parse a ANSI X12N data file.  Validate against a map and codeset values.
 Create XML, HTML, and 997/999 documents based on the data file.
 """
+from __future__ import annotations
+from collections.abc import Callable
+from typing import Any, TextIO
 
 import logging
 
@@ -23,11 +26,13 @@ import pyx12.error_html
 import pyx12.errors
 import pyx12.map_index
 import pyx12.map_if
+import pyx12.params
 import pyx12.x12file
 from pyx12.map_walker import walk_tree
 import pyx12.x12xml_simple
 
-def _reset_counter_to_isa_counts(walker):
+
+def _reset_counter_to_isa_counts(walker: walk_tree) -> None:
     """
     Reset ISA instance counts
     """
@@ -35,7 +40,8 @@ def _reset_counter_to_isa_counts(walker):
     walker.counter.increment('/ISA_LOOP')
     walker.counter.increment('/ISA_LOOP/ISA')
 
-def _reset_counter_to_gs_counts(walker):
+
+def _reset_counter_to_gs_counts(walker: walk_tree) -> None:
     """
     Reset GS instance counts
     """
@@ -43,9 +49,17 @@ def _reset_counter_to_gs_counts(walker):
     walker.counter.increment('/ISA_LOOP/GS_LOOP')
     walker.counter.increment('/ISA_LOOP/GS_LOOP/GS')
 
-def x12n_document(param, src_file, fd_997, fd_html,
-                  fd_xmldoc=None, xslt_files=None, map_path=None,
-                  callback=None):
+
+def x12n_document(
+    param: pyx12.params.ParamsBase,
+    src_file: str | TextIO,
+    fd_997: TextIO | None,
+    fd_html: TextIO | None,
+    fd_xmldoc: TextIO | None = None,
+    xslt_files: Any = None,
+    map_path: str | None = None,
+    callback: Callable[..., Any] | None = None,
+) -> bool:
     """
     Primary X12 validation function
     :param param: pyx12.param instance
@@ -76,8 +90,11 @@ def x12n_document(param, src_file, fd_997, fd_html,
     map_index_if = pyx12.map_index.map_index(map_path)
     node = control_map.getnodebypath('/ISA_LOOP/ISA')
     walker = walk_tree()
-    icvn = fic = vriic = tspc = None
-    cur_map = None  # we do not initially know the X12 transaction type
+    icvn: str | None = None
+    fic: str | None = None
+    vriic: str | None = None
+    tspc: str | None = None
+    cur_map: Any = None  # we do not initially know the X12 transaction type
     #XXX Generate TA1 if needed.
 
     if fd_html:
@@ -200,7 +217,7 @@ def x12n_document(param, src_file, fd_997, fd_html,
         if fd_html:
             if node is not None and node.is_first_seg_in_loop():
                 html.loop(node.get_parent())
-            err_node_list = []
+            err_node_list: list[Any] = []
             while True:
                 try:
                     next(err_iter)

--- a/pyx12/x12xml.py
+++ b/pyx12/x12xml.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -11,16 +11,24 @@
 """
 Create an XML rendering of the X12 document
 """
+from __future__ import annotations
+from typing import Any, Literal, TextIO
 
 import os.path
 
 # Intrapackage imports
+import pyx12.segment
 from .errors import EngineError
 from .xmlwriter import XMLWriter
 from .map_walker import pop_to_parent_loop
 
+
 class x12xml:
-    def __init__(self, fd, type, dtd_urn):
+
+    writer: XMLWriter
+    last_path: list[str]
+
+    def __init__(self, fd: TextIO, type: str, dtd_urn: str | None) -> None:
         self.writer = XMLWriter(fd)
         if dtd_urn:
             self.writer.doctype( \
@@ -28,23 +36,23 @@ class x12xml:
                 "-//J Holland//DTD XML X12 Document Conversion1.0//EN//XML", \
                 dtd_urn)
         self.writer.push(type)
-        self.last_path = None
+        self.last_path = []
 
-    def close(self):
+    def close(self) -> None:
         """
         Pop any XML elements still on the writer's stack. Idempotent.
         """
         while len(self.writer) > 0:
             self.writer.pop()
 
-    def __enter__(self):
+    def __enter__(self) -> x12xml:
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
         self.close()
         return False
 
-    def seg(self, seg_node, seg_data):
+    def seg(self, seg_node: Any, seg_data: pyx12.segment.Segment) -> None:
         """
         Generate XML for the segment data and matching map node
 
@@ -76,32 +84,39 @@ class x12xml:
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
             _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
+            assert _ele is not None  # within range(len(seg_data))
             if child_node.usage == 'N' or _ele.is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node_id)
                 self.writer.push(xname, attrib)
                 comp_data = seg_data.get('{idx:02d}'.format(idx=i + 1))
+                assert isinstance(comp_data, pyx12.segment.Composite)
                 for j in range(len(comp_data)):
                     subele_node = child_node.get_child_node_by_idx(j)
                     (xname, attrib) = self._get_subele_info(subele_node.id)
                     self.writer.elem(xname, comp_data[j].get_value(), attrib)
                 self.writer.pop()  # end composite
             elif child_node.is_element():
-                _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
-                if _ele == '':
+                ele_val = seg_data.get_value('{idx:02d}'.format(idx=i + 1))
+                if ele_val == '' or ele_val is None:
                     pass
                     #self.writer.empty(u"ele", attrs={u'id': child_node.id})
                 else:
                     (xname, attrib) = self._get_ele_info(child_node.id)
-                    _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
-                    self.writer.elem(xname, _ele, attrib)
+                    self.writer.elem(xname, ele_val, attrib)
             else:
                 raise EngineError('Node must be a either an element or a composite')
         self.writer.pop()  # end segment
         self.last_path = cur_path
 
-    def seg_context(self, seg_node, seg_data, pop_loops, push_loops):
+    def seg_context(
+        self,
+        seg_node: Any,
+        seg_data: pyx12.segment.Segment,
+        pop_loops: list[Any],
+        push_loops: list[Any],
+    ) -> None:
         """
         Generate XML for the segment data and matching map node
 
@@ -123,38 +138,39 @@ class x12xml:
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
             _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
+            assert _ele is not None  # within range(len(seg_data))
             if child_node.usage == 'N' or _ele.is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node.id)
                 self.writer.push(xname, attrib)
                 comp_data = seg_data.get('{idx:02d}'.format(idx=i + 1))
+                assert isinstance(comp_data, pyx12.segment.Composite)
                 for j in range(len(comp_data)):
                     subele_node = child_node.get_child_node_by_idx(j)
                     (xname, attrib) = self._get_subele_info(subele_node.id)
                     self.writer.elem(xname, comp_data[j].get_value(), attrib)
                 self.writer.pop()  # end composite
             elif child_node.is_element():
-                _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
-                if _ele == '':
+                ele_val = seg_data.get_value('{idx:02d}'.format(idx=i + 1))
+                if ele_val == '' or ele_val is None:
                     pass
                     #self.writer.empty(u"ele", attrs={u'id': child_node.id})
                 else:
                     (xname, attrib) = self._get_ele_info(child_node.id)
-                    _ele = seg_data.get('{idx:02d}'.format(idx=i + 1))
-                    self.writer.elem(xname, _ele, attrib)
+                    self.writer.elem(xname, ele_val, attrib)
             else:
                 raise EngineError('Node must be a either an element or a composite')
         self.writer.pop()  # end segment
 
-    def _path_list(self, path_str):
+    def _path_list(self, path_str: str) -> list[str]:
         """
         Get list of path nodes from path string
         :rtype: list
         """
         return [x for x in path_str.split('/') if x != '']
 
-    def _get_path_match_idx(self, last_path, cur_path):
+    def _get_path_match_idx(self, last_path: list[str], cur_path: list[str]) -> int:
         """
         Get the index of the last matching path nodes
         """
@@ -165,48 +181,54 @@ class x12xml:
             match_idx += 1
         return match_idx
 
-    def _get_node_id(self, seg_node, parent=None, seg_data=None):
+    def _get_node_id(
+        self,
+        seg_node: Any,
+        parent: Any = None,
+        seg_data: pyx12.segment.Segment | None = None,
+    ) -> str:
         """
         Base node id function
         """
-        return seg_node.id
+        result: str = seg_node.id
+        return result
 
-    def _get_loop_info(self, loop_id):
+    def _get_loop_info(self, loop_id: str) -> tuple[str, dict[str, str]]:
         """
         Base loop node value
         """
         loop_name = loop_id
-        attrib = {}
+        attrib: dict[str, str] = {}
         return (loop_name, attrib)
 
-    def _get_seg_info(self, seg_id):
+    def _get_seg_info(self, seg_id: str) -> tuple[str, dict[str, str]]:
         """
         Base segment node value
         """
         seg_name = seg_id
-        attrib = {}
+        attrib: dict[str, str] = {}
         return (seg_name, attrib)
 
-    def _get_comp_info(self, comp_id):
+    def _get_comp_info(self, comp_id: str) -> tuple[str, dict[str, str]]:
         """
         Base composite node value
         """
         comp_name = comp_id
-        attrib = {}
+        attrib: dict[str, str] = {}
         return (comp_name, attrib)
 
-    def _get_ele_info(self, ele_id):
+    def _get_ele_info(self, ele_id: str) -> tuple[str, dict[str, str]]:
         """
         Base element node value
         """
         name = ele_id
-        attrib = {}
+        attrib: dict[str, str] = {}
         return (name, attrib)
 
-    def _get_subele_info(self, subele_id):
+    def _get_subele_info(self, subele_id: str) -> tuple[str, dict[str, str]]:
         """
         Base sub-element node value
         """
         name = subele_id
-        attrib = {}
+        attrib: dict[str, str] = {}
         return (name, attrib)

--- a/pyx12/x12xml_simple.py
+++ b/pyx12/x12xml_simple.py
@@ -1,5 +1,5 @@
 ######################################################################
-# Copyright 
+# Copyright
 #   John Holland <john@zoner.org>
 # All rights reserved.
 #
@@ -11,23 +11,27 @@
 """
 Create a XML rendering of the X12 document
 """
+from __future__ import annotations
+from typing import Any, TextIO
 
 from os.path import commonprefix
 import logging
 
 # Intrapackage imports
+import pyx12.segment
 from .errors import EngineError
 from .x12xml import x12xml
 from .map_walker import pop_to_parent_loop
 
 logger = logging.getLogger('pyx12.x12xml.simple')
 
+
 class x12xml_simple(x12xml):
-    def __init__(self, fd, dtd_urn=None):
+    def __init__(self, fd: TextIO, dtd_urn: str | None = None) -> None:
         x12xml.__init__(self, fd, "x12simple", dtd_urn)
         self.last_path = []
 
-    def seg(self, seg_node, seg_data):
+    def seg(self, seg_node: Any, seg_data: pyx12.segment.Segment) -> None:
         """
         Generate XML for the segment data and matching map node
 
@@ -64,54 +68,58 @@ class x12xml_simple(x12xml):
         self.writer.push(xname, attrib)
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
-            if child_node.usage == 'N' or seg_data.get('%02i' % (i + 1)).is_empty():
+            _ele = seg_data.get('%02i' % (i + 1))
+            assert _ele is not None  # within range(len(seg_data))
+            if child_node.usage == 'N' or _ele.is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node_id)
                 self.writer.push(xname, attrib)
                 comp_data = seg_data.get('%02i' % (i + 1))
+                assert isinstance(comp_data, pyx12.segment.Composite)
                 for j in range(len(comp_data)):
                     subele_node = child_node.get_child_node_by_idx(j)
                     (xname, attrib) = self._get_subele_info(subele_node.id)
                     self.writer.elem(xname, comp_data[j].get_value(), attrib)
                 self.writer.pop()  # end composite
             elif child_node.is_element():
-                if seg_data.get_value('%02i' % (i + 1)) == '':
+                ele_val = seg_data.get_value('%02i' % (i + 1))
+                if ele_val == '' or ele_val is None:
                     pass
                     #self.writer.empty(u"ele", attrs={u'id': child_node.id})
                 else:
                     (xname, attrib) = self._get_ele_info(child_node.id)
-                    self.writer.elem(xname, seg_data.get_value('%02i' % (i + 1)), attrib)
+                    self.writer.elem(xname, ele_val, attrib)
             else:
                 raise EngineError('Node must be a either an element or a composite')
         self.writer.pop()  # end segment
         self.last_path = cur_path
 
-    def _get_loop_info(self, loop_id):
+    def _get_loop_info(self, loop_id: str) -> tuple[str, dict[str, str]]:
         """
         Override loop node value
         """
         return ("loop", {'id': loop_id})
 
-    def _get_seg_info(self, seg_id):
+    def _get_seg_info(self, seg_id: str) -> tuple[str, dict[str, str]]:
         """
         Override segment node value
         """
         return ("seg", {'id': seg_id})
 
-    def _get_comp_info(self, comp_id):
+    def _get_comp_info(self, comp_id: str) -> tuple[str, dict[str, str]]:
         """
         Override composite node value
         """
         return ("comp",  {'id': comp_id})
 
-    def _get_ele_info(self, ele_id):
+    def _get_ele_info(self, ele_id: str) -> tuple[str, dict[str, str]]:
         """
         Override element node value
         """
         return ("ele", {'id': ele_id})
 
-    def _get_subele_info(self, subele_id):
+    def _get_subele_info(self, subele_id: str) -> tuple[str, dict[str, str]]:
         """
         Override sub-element node value
         """


### PR DESCRIPTION
## Summary

Bundles type-annotation pass for five medium-sized production modules:

- \`x12xml.py\` — XML rendering base class
- \`x12xml_simple.py\` — simple XML rendering subclass
- \`map_walker.py\` — walks the map_if tree to match segments
- \`x12n_document.py\` — top-level \`x12n_document()\` driver
- \`x12metadata.py\` — metadata extraction (headers + node summary)

Same pattern as previous typing PRs. Where production callees aren't typed yet (\`map_if\`, \`error_handler\`), function parameters that take their results use \`Any\`.

## Per-file notes

### [pyx12/x12xml.py](pyx12/x12xml.py) / [pyx12/x12xml_simple.py](pyx12/x12xml_simple.py)
- \`fd: TextIO\` (matches \`XMLWriter\`'s contract).
- \`last_path: list[str]\` declared at class level; both \`__init__\`s now initialize it to \`[]\`.
- \`Segment.get()\` returns \`Element | Composite | None\`; explicit \`assert\`s added where existing loop bounds make None and Element-vs-Composite ambiguity safe to ignore at runtime.
- Element branch now uses \`get_value()\` (\`str | None\`) instead of \`get()\` (\`Element | Composite | None\`).
- \`__exit__ -> Literal[False]\`.

### [pyx12/map_walker.py](pyx12/map_walker.py)
- All public and private methods get full signatures.
- \`mandatory_segs_missing\` typed as \`list\` of 7-tuples \`(node, fake_seg, code, str, seg_count, cur_line, ls_id)\`.
- \`node\` and \`errh\` remain \`Any\` until \`map_if\` and \`error_handler\` are annotated.

### [pyx12/x12n_document.py](pyx12/x12n_document.py)
- \`x12n_document(...)\` full signature: \`param: ParamsBase\`, \`src_file: str | TextIO\`, \`fd_*: TextIO | None\`, \`callback: Callable[..., Any] | None\`, returns \`bool\`.
- Loop-local control variables (\`icvn\`, \`fic\`, \`vriic\`, \`tspc\`) annotated as \`str | None\` at first declaration so mypy can flow-track through the segment loop.

### [pyx12/x12metadata.py](pyx12/x12metadata.py)
- \`get_x12file_metadata(...) -> tuple[bool, dict[str, Any] | None, dict[str, Any] | None]\`
- \`get_x12file_metadata_headers(...) -> tuple[bool, dict[str, Any] | None]\`
- 🧹 Drive-by: removed a leftover \`sys.path.insert\` hack at the top of the file (D6-style, missed in the original scripts cleanup).

## Latent bug fix

\`x12xml.__init__\` previously set \`self.last_path = None\`. The first \`seg()\` call would do \`len(last_path)\` which would \`TypeError\` on \`None\`. The simple subclass already worked around this by re-initializing \`last_path = []\`. Now the base class uses \`[]\` from the start, so direct \`x12xml\` instantiation also works.

## Effect on mypy baseline

| | Errors | Production files |
|---|---:|---:|
| Before (post #101) | 714 | 9 |
| After this PR | 585 | 5 |

Per-file:
\`\`\`
x12xml          38 -> 0
x12xml_simple   21 -> 0
map_walker      34 -> 0
x12n_document   46 -> 31  (no-untyped-call from map_if, error_handler)
x12metadata     37 -> 13  (same cascading reason)
                ---
                176 -> 44  (-132 directly + 3 elsewhere)
\`\`\`

The remaining 31 / 13 errors in \`x12n_document\` / \`x12metadata\` are entirely \`no-untyped-call\` from cascading into \`pyx12.map_if\` and \`pyx12.error_handler\`. They will clear automatically when those two giants are typed in subsequent PRs.

## Verification

- \`uv run mypy\` → 585 errors (down from 714)
- Full pytest suite: 521/521 pass

## Test plan

- [x] mypy clean on the 3 fully-isolated files (x12xml, x12xml_simple, map_walker)
- [x] mypy reduced on the 2 cascade-dependent files (x12n_document, x12metadata) — remainder is no-untyped-call from untyped callees
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)