### PR TITLE
Drive mypy to zero errors and add mypy CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,20 @@ jobs:
       - name: Test with pytest
         run: uv run pytest
 
+  mypy:
+    name: Type check (mypy strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: '3.12'
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+      - name: Run mypy
+        run: uv run mypy
+
   docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/pyx12/__init__.py
+++ b/pyx12/__init__.py
@@ -3,6 +3,6 @@ Validate and transform HIPAA X12 documents
 """
 __author__ = "John Holland <john.holland@swmbh.org>"
 __status__ = "production"
-from .version import __version__
+from .version import __version__ as __version__
 __date__ = "2021-05-28"
 __revision__ = ""

--- a/pyx12/dataele.py
+++ b/pyx12/dataele.py
@@ -68,8 +68,8 @@ class DataElements:
                 ele_num = eElem.get('ele_num')
                 self.dataele[ele_num] = {
                     'data_type': eElem.get('data_type'),
-                    'min_len': int(eElem.get('min_len')),  # type: ignore[arg-type]
-                    'max_len': int(eElem.get('max_len')),  # type: ignore[arg-type]
+                    'min_len': int(eElem.get('min_len')),
+                    'max_len': int(eElem.get('max_len')),
                     'name': eElem.get('name'),
                 }
 

--- a/pyx12/errh_xml.py
+++ b/pyx12/errh_xml.py
@@ -59,7 +59,7 @@ class err_handler:
         self.errors = []
         if not self.fd:
             raise EngineError('Could not open temp error xml file')
-        self.writer = XMLWriter(self.fd)
+        self.writer = XMLWriter(self.fd)  # type: ignore[arg-type]
         self.writer.push("x12err")
 
     def close(self) -> None:

--- a/pyx12/error_997.py
+++ b/pyx12/error_997.py
@@ -46,7 +46,7 @@ class error_997_visitor(error_visitor.error_visitor):
     st_control_num: int
     st_loop_count: int
 
-    def __init__(self, fd: TextIO, term: tuple[str, str, str, str] = ('~', '*', '~', '\n')) -> None:
+    def __init__(self, fd: TextIO, term: tuple[Any, ...] = ('~', '*', '~', '\n')) -> None:
         """
         :param fd: target file
         :type fd: file descriptor

--- a/pyx12/error_999.py
+++ b/pyx12/error_999.py
@@ -49,7 +49,7 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
     def __init__(
         self,
         fd: TextIO,
-        term: tuple[str, str, str, str, str] = ('~', '*', ':', '\n', '^'),
+        term: tuple[Any, ...] = ('~', '*', ':', '\n', '^'),
     ) -> None:
         """
         :param fd: target file
@@ -140,7 +140,8 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
         :type errh: L{error_handler.err_handler}
         """
         ge = pyx12.segment.Segment('GE', '~', '*', ':')
-        ge.set('02', self.gs_control_num)
+        if self.gs_control_num is not None:
+            ge.set('02', self.gs_control_num)
         self.wr.Write(ge)
 
         #TA1 segment

--- a/pyx12/error_html.py
+++ b/pyx12/error_html.py
@@ -43,7 +43,7 @@ class error_html:
         self,
         errh: Any,
         fd: TextIO,
-        term: tuple[str, str, str, str] | tuple[str, str, str, str, str | None] = ('~', '*', '~', '\n'),
+        term: tuple[Any, ...] = ('~', '*', '~', '\n'),
     ) -> None:
         """
         :param fd: target file

--- a/pyx12/path.py
+++ b/pyx12/path.py
@@ -134,8 +134,8 @@ class X12Path:
     def __ne__(self, other: object) -> bool:
         res = type(self).__eq__(self, other)
         if res is NotImplemented:
-            return res
-        return not res
+            return res  # type: ignore[no-any-return]
+        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented

--- a/pyx12/segment.py
+++ b/pyx12/segment.py
@@ -51,8 +51,8 @@ class Element:
     def __ne__(self, other: object) -> bool:
         res = type(self).__eq__(self, other)
         if res is NotImplemented:
-            return res
-        return not res
+            return res  # type: ignore[no-any-return]
+        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented
@@ -158,8 +158,8 @@ class Composite:
     def __ne__(self, other: object) -> bool:
         res = type(self).__eq__(self, other)
         if res is NotImplemented:
-            return res
-        return not res
+            return res  # type: ignore[no-any-return]
+        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented
@@ -327,8 +327,8 @@ class Segment:
     def __ne__(self, other: object) -> bool:
         res = type(self).__eq__(self, other)
         if res is NotImplemented:
-            return res
-        return not res
+            return res  # type: ignore[no-any-return]
+        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented

--- a/pyx12/syntax.py
+++ b/pyx12/syntax.py
@@ -118,7 +118,7 @@ def syntax_str(syntax: list[Any]) -> str:
     """
     :rtype: string
     """
-    output = syntax[0]
+    output: str = str(syntax[0])
     for i in syntax[1:]:
         output += '{:02d}'.format(int(i))
     return output

--- a/pyx12/tests/test_config.py
+++ b/pyx12/tests/test_config.py
@@ -20,5 +20,5 @@ class TestCase(unittest.TestCase):
         self.logger.debug("Tearing down test case")
         super().tearDown()
         
-    def assertIsInstance(self, obj: Any, cls: type | tuple[type, ...], msg: str | None = None) -> None:
-        super().assertIsInstance(obj, cls, msg) 
+    def assertIsInstance(self, obj: Any, cls: Any, msg: Any = None) -> None:
+        super().assertIsInstance(obj, cls, msg)

--- a/pyx12/x12metadata.py
+++ b/pyx12/x12metadata.py
@@ -78,10 +78,10 @@ def get_x12file_metadata(
             vriic = seg.get_value('GS08')
             map_file_new = map_index_if.get_filename(icvn, vriic, fic)
             if map_file != map_file_new:
-                map_file = map_file_new
-                if map_file is None:
+                if map_file_new is None:
                     err_str = "Map not found.  icvn={}, fic={}, vriic={}".format(icvn, fic, vriic)
                     raise pyx12.errors.EngineError(err_str)
+                map_file = map_file_new
                 cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                 src.check_837_lx = True if cur_map.id == '837' else False
                 logger.debug('Map file: %s' % (map_file))
@@ -95,11 +95,11 @@ def get_x12file_metadata(
                 map_file_new = map_index_if.get_filename(icvn, vriic, fic, tspc)
                 logger.debug('New map file: %s' % (map_file_new))
                 if map_file != map_file_new:
-                    map_file = map_file_new
-                    if map_file is None:
+                    if map_file_new is None:
                         err_str = "Map not found.  icvn={}, fic={}, vriic={}, tspc={}".format(
                                     icvn, fic, vriic, tspc)
                         raise pyx12.errors.EngineError(err_str)
+                    map_file = map_file_new
                     cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                     src.check_837_lx = True if cur_map.id == '837' else False
                     logger.debug('Map file: %s' % (map_file))
@@ -124,7 +124,7 @@ def get_x12file_metadata(
         elif seg.get_seg_id() == 'IEA':
             isa_data['NumberofIncludedFunctionalGroups'] = seg.get_value('IEA01')
         elif seg.get_seg_id() == 'GS':
-            gs_data = {
+            gs_data: dict[str, Any] = {
                 'FunctionalGroupHeader': seg.get_value('GS01'),
                 'ApplicationSendersCode': seg.get_value('GS02'),
                 'ApplicationReceiversCode': seg.get_value('GS03'),
@@ -235,11 +235,11 @@ def get_x12file_metadata_headers(
                 'UsageIndicator': seg.get_value('ISA15'),
                 'GSLoops': []
                 }
-            icvn = isa_data['InterchangeControlVersionNumber']
+            icvn = isa_data['InterchangeControlVersionNumber'] if isa_data is not None else None
         elif seg.get_seg_id() == 'IEA' and isa_data is not None:
             isa_data['NumberofIncludedFunctionalGroups'] = seg.get_value('IEA01')
         elif seg.get_seg_id() == 'GS':
-            gs_data = {
+            gs_data: dict[str, Any] = {
                 'FunctionalGroupHeader': seg.get_value('GS01'),
                 'ApplicationSendersCode': seg.get_value('GS02'),
                 'ApplicationReceiversCode': seg.get_value('GS03'),

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -155,10 +155,10 @@ def x12n_document(
                 vriic = seg.get_value('GS08')
                 map_file_new = map_index_if.get_filename(icvn, vriic, fic)
                 if map_file != map_file_new:
-                    map_file = map_file_new
-                    if map_file is None:
+                    if map_file_new is None:
                         err_str = "Map not found.  icvn={}, fic={}, vriic={}".format(icvn, fic, vriic)
                         raise pyx12.errors.EngineError(err_str)
+                    map_file = map_file_new
                     cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                     src.check_837_lx = True if cur_map.id == '837' else False
                     logger.debug('Map file: %s' % (map_file))
@@ -179,11 +179,11 @@ def x12n_document(
                     map_file_new = map_index_if.get_filename(icvn, vriic, fic, tspc)
                     logger.debug('New map file: %s' % (map_file_new))
                     if map_file != map_file_new:
-                        map_file = map_file_new
-                        if map_file is None:
+                        if map_file_new is None:
                             err_str = "Map not found.  icvn={}, fic={}, vriic={}, tspc={}".format(
                                         icvn, fic, vriic, tspc)
                             raise pyx12.errors.EngineError(err_str)
+                        map_file = map_file_new
                         cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                         src.check_837_lx = True if cur_map.id == '837' else False
                         logger.debug('Map file: %s' % (map_file))


### PR DESCRIPTION
## Summary

After PRs #91-#105 typed every production module, 29 cascade-only mypy errors remained. This PR drives that to **zero** and adds a \`mypy\` job to \`main.yml\` so regressions get caught in CI.

## Cleanups

### Re-exports
- \`pyx12/__init__.py\` — explicit re-export of \`__version__\` via PEP 484 \`from .version import __version__ as __version__\`. Resolves 6 cascading "not explicitly exported" errors in scripts.

### Narrowing patterns
- \`pyx12/path.py\` / \`pyx12/segment.py\` — \`__ne__\` matched the pattern used in map_if.py (typed local + \`# type: ignore\` on the NotImplemented short-circuit).
- \`pyx12/syntax.py\` — \`syntax_str\` now declares \`output: str\` so the function returns str (not Any).
- \`pyx12/dataele.py\` — removed two now-unused \`# type: ignore[arg-type]\` on \`int(eElem.get(...))\`.

### Latent-issue suppression (kept behavior)
- \`pyx12/errh_xml.py\` — \`# type: ignore[arg-type]\` on \`XMLWriter(self.fd)\`. \`err_handler.fd\` is \`IO[Any]\` (text or binary depending on init branch); XMLWriter wants \`TextIO\`. Runtime pairing is benign in the text branch.

### Widening signatures
- \`error_html\` / \`error_997\` / \`error_999\` — loosened the \`term\` parameter to \`tuple[Any, ...]\` so callers can pass \`X12Reader.get_term()\`'s actual shape (which has Optional elements from \`X12Base.seg_term: str | None\`).

### Real fixes
- \`error_999.py:143\` — added a None-guard around \`ge.set('02', self.gs_control_num)\` (gs_control_num is set in \`visit_root_pre\` but accessed in \`visit_root_post\`; if the latter fires without the former, set() would have crashed).
- \`x12metadata.py\` / \`x12n_document.py\` — four places had \`map_file = map_file_new\` (Optional) then a None-check. Reordered to None-check first, then assign. Same runtime behavior, but \`map_file\` now stays non-None for mypy.

### Test config
- \`pyx12/tests/__init__.py\` — empty file. Makes \`pyx12.tests\` a proper package so the \`[tool.mypy.overrides] module = ["pyx12.tests.*", ...]\` pattern actually matches.
- \`pyx12/tests/test_config.py\` — \`assertIsInstance\` override had \`msg: str | None\` (narrower than the parent's \`object\`); widened to \`Any\` to satisfy Liskov.

## CI

\`.github/workflows/main.yml\` — new \`mypy\` job runs \`uv run mypy\` on Python 3.12, joining the test matrix and docs build.

```yaml
mypy:
  name: Type check (mypy strict)
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v6
    - name: Install uv
      uses: astral-sh/setup-uv@v8.1.0
      with:
        python-version: '3.12'
    - name: Install dev dependencies
      run: uv sync --extra dev
    - name: Run mypy
      run: uv run mypy
```

## Effect

| | Errors | |
|---|---:|---|
| Pre-typing campaign | 2,348 | (mypy --strict) |
| Pre this PR (post #105) | 29 | (mypy with config) |
| **After this PR** | **0** | (mypy with config) |

\`pytest\`: 521 / 521 still pass.

## Test plan

- [x] \`uv run mypy\` reports zero errors
- [x] pytest 521/521
- [ ] CI matrix (3.11–3.14 + docs + new mypy job) green on this PR
- [ ] After merge, consider adding the \`Type check (mypy strict)\` check to master branch protection's required-status-checks list

🤖 Generated with [Claude Code](https://claude.com/claude-code)