### PR TITLE
codes: add missing CMS Place of Service codes

### DIFF
--- a/pyx12/map/codes.xml
+++ b/pyx12/map/codes.xml
@@ -2796,6 +2796,7 @@
       <code>07</code>
       <code>08</code>
       <code>09</code>
+      <code>10</code>
       <code>11</code>
       <code>12</code>
       <code>13</code>
@@ -2812,6 +2813,7 @@
       <code>24</code>
       <code>25</code>
       <code>26</code>
+      <code>27</code>
       <code>31</code>
       <code>32</code>
       <code>33</code>
@@ -2827,10 +2829,12 @@
       <code>55</code>
       <code>56</code>
       <code>57</code>
+      <code>58</code>
       <code>60</code>
       <code>61</code>
       <code>62</code>
       <code>65</code>
+      <code>66</code>
       <code>71</code>
       <code>72</code>
       <code>81</code>


### PR DESCRIPTION
## Summary
- Add codes 10, 27, 58, 66 to the `pos` codeset in `pyx12/map/codes.xml` to match the current CMS Place of Service code set
  - 10 — Telehealth Provided in Patient's Home
  - 27 — Outreach Site/Street
  - 58 — Non-residential Opioid Treatment Facility
  - 66 — Programs of All-Inclusive Care for the Elderly (PACE) Center

Source: [CMS Place of Service Code Set](https://www.cms.gov/medicare/coding-billing/place-of-service-codes/code-sets)

## Test plan
- [x] Full test suite passes locally (521 tests, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)