### PR TITLE
ci: add sphinx linkcheck step to docs job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,17 @@ jobs:
         run: uv sync --extra docs
       - name: Build HTML docs
         run: uv run sphinx-build -b html docs docs/_build/html
+      - name: Check external links
+        continue-on-error: true
+        run: uv run sphinx-build -b linkcheck --keep-going docs docs/_build/linkcheck
       - name: Upload docs artifact
         uses: actions/upload-artifact@v7
         with:
           name: docs-html
           path: docs/_build/html
+      - name: Upload linkcheck report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: linkcheck-report
+          path: docs/_build/linkcheck

--- a/pyx12/xmlwriter.py
+++ b/pyx12/xmlwriter.py
@@ -18,7 +18,7 @@ class XMLWriter:
         >>>writer = XMLWriter()
         >>>writer.doctype(
         ... u"xsa", u"-//LM Garshol//DTD XML Software Autoupdate 1.0//EN//XML",
-        ... u"http://www.garshol.priv.no/download/xsa/xsa.dtd")
+        ... u"https://www.garshol.priv.no/download/xsa/xsa.dtd")
         >>>#Notice: there is no error checking to ensure that the root element
         >>>#specified in the doctype matches the top-level element generated
         >>>writer.push(u"xsa")


### PR DESCRIPTION
## Summary
- Adds `sphinx-build -b linkcheck --keep-going docs docs/_build/linkcheck` after the HTML build in the existing **Build documentation** job.
- `continue-on-error: true` so transient external failures (CMS/HHS pages rot constantly) never block PRs.
- Uploads a `linkcheck-report` artifact (`if: always()`) so the report is available even when the step is reported as soft-failed.
- Drive-by: upgrades the only redirected URL surfaced by the first local run — the XSA DTD reference in [pyx12/xmlwriter.py](pyx12/xmlwriter.py)'s docstring — from `http://` to `https://`.

## Test plan
- [x] `sphinx-build -b linkcheck` runs clean locally (zero broken links, zero redirects after the http→https fix)
- [x] `pytest pyx12/test/` — 521 passed
- [ ] Confirm the new step runs and the artifact appears on the PR's CI checks page

🤖 Generated with [Claude Code](https://claude.com/claude-code)