### PR TITLE
docs: add Contributing section to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ uv.lock
 docs/_build/
 docs/_generated/
 docs/api/
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -39,6 +39,85 @@ Fixes common X12 structural errors.  Can add or remove line breaks.  Can fix loo
 
     uv pip install pyx12
 
+# Contributing
+
+The most useful contributions are **new implementation-guide maps** —
+either upgrading an existing 4010 map to its 5010 counterpart, or adding
+support for an X12 transaction pyx12 doesn't yet cover. Pyx12's design
+already handles the engine; the bottleneck is map coverage.
+
+## Where the maps live
+
+XML maps live under `pyx12/map/`, one file per (transaction, version)
+pair, named like `<transaction>.<version>.<X-number>[.A<n>].xml` —
+e.g. `834.4010.X095.A1.xml`, `837.5010.X222.A1.xml`. The index that
+pyx12 consults at runtime is `pyx12/map/maps.xml`; each entry binds a
+`(vriic, fic[, tspc])` triple to a map filename. ICVN is the ISA12
+version, VRIIC is GS08, FIC is GS01, TSPC is the type sub-code (used
+only for 278).
+
+## Converting a 4010 map to 5010
+
+Several 4010 maps don't yet have 5010 siblings — the candidates are
+listed in the commented-out block in `maps.xml` (270/271 eligibility,
+276/277 claim status, 277U, 278 services review, 837D dental, 841). To
+add one:
+
+1. Get the 5010 implementation guide for the transaction from
+   [X12.org](https://x12.org/products) or its HIPAA companion guide.
+2. Copy the existing 4010 map as a starting point — `cp
+   pyx12/map/270.4010.X092.A1.xml pyx12/map/270.5010.X279.A1.xml` (the
+   X-number changes between versions).
+3. Walk the IG diff and apply structural changes: new loops, new
+   segments, renamed elements, added or removed code values, changed
+   `usage` flags, changed `max_use`, changed `repeat`, changed syntax
+   rules. The 834.4010 ↔ 834.5010 pair is a good reference for the
+   typical scope of changes.
+4. Update the `<valid_codes>` lists from the 5010 code list. Many
+   external-code references (`<external>`) stay pointed at the same
+   bundled list in `codes.xml` but the lists themselves may need
+   refreshing — see the commit history for `codes.xml` for the pattern.
+5. Register the new file under the `<version icvn="00501">` block in
+   `maps.xml`:
+
+   ```xml
+   <map vriic="005010X279A1" fic="HS" abbr="270">270.5010.X279.A1.xml</map>
+   ```
+6. Add a fixture and a test. Tests live under `pyx12/test/`; the
+   simplest pattern is a `test_x12n_document.py` entry that runs
+   `x12n_document` against a sample file from the IG and compares the
+   997/999 output, or a focused `test_map_if_load.py` entry that just
+   confirms the map parses cleanly.
+
+## Adding a new X12 IG
+
+The same shape applies — pyx12 is HIPAA-focused but the map engine is
+transaction-agnostic. Drop a new XML map into `pyx12/map/`, register it
+in `maps.xml` with the right `(icvn, vriic, fic[, tspc])`, and you're
+in. If the transaction uses code lists that aren't already bundled,
+add them under `<codeset>` blocks in `codes.xml` and reference them
+from your map's `<external>` elements.
+
+## Running the project
+
+```bash
+# Set up the dev environment
+uv sync --extra dev
+
+# Tests
+uv run pytest
+
+# Type check
+uv run mypy
+
+# Format
+uv run black pyx12/
+uv run isort pyx12/
+```
+
+A green `pytest` and `mypy --strict` run is required for CI to pass.
+PRs welcome via [github.com/azoner/pyx12](https://github.com/azoner/pyx12).
+
 # Licensing
 
 Pyx12 uses a BSD license. The full license text is included with the source code for the package. 


### PR DESCRIPTION
## Summary
Adds a Contributing section to [README.md](README.md) focused on the actual bottleneck for pyx12: **implementation-guide map coverage**. The map engine is transaction-agnostic; what slows new transactions or 5010 versions down is just having a map file written.

### Sections
- **Where the maps live** — naming convention, what `pyx12/map/maps.xml` encodes (`(vriic, fic[, tspc]) → filename`), and the meaning of ICVN / VRIIC / FIC / TSPC
- **Converting a 4010 map to 5010** — six concrete steps (get the IG, copy the existing map, walk the diff, refresh code lists, register in `maps.xml`, add a fixture/test), with the five 4010-only maps still commented out in `maps.xml` called out as highest-leverage targets (270/271, 276/277U, 278, 837D, 841)
- **Adding a new X12 IG** — same shape, since the engine is transaction-agnostic
- **Running the project** — standard dev-loop commands lifted from [CLAUDE.md](CLAUDE.md) for non-Claude contributors

### Note on link syntax
Avoided markdown `[text](path)` for repo-relative paths because myst can't resolve them when this README is included into the RTD docs site (`docs/readme.md` does an `:include: ../README.md`). Repo paths are plain code spans; only external URLs are linked.

## Test plan
- [x] `sphinx-build -b html docs docs/_build/html` — clean (1 pre-existing benign warning unchanged, no new myst xref warnings)
- [ ] Eyeball rendering on GitHub (the primary surface for this change) and on the RTD readme.html page

🤖 Generated with [Claude Code](https://claude.com/claude-code)