### PR TITLE
chore: replace bare except: with except Exception: in tests

### DIFF
--- a/pyx12/test/test_map_if_load.py
+++ b/pyx12/test/test_map_if_load.py
@@ -43,6 +43,6 @@ class LoadAllMapsNoErrors(unittest.TestCase):
         for map in maps:
             try:
                 map = pyx12.map_if.load_map_file(map, param)
-            except:
+            except Exception:
                 print(map)
                 raise

--- a/pyx12/test/test_rawx12file.py
+++ b/pyx12/test/test_rawx12file.py
@@ -13,7 +13,7 @@ class X12fileTestCase(unittest.TestCase):
                 fd = StringIO(x12str)
             else:
                 fd = StringIO()
-        except:
+        except Exception:
             if x12str:
                 fd = StringIO(x12str, encoding="ascii")
             else:

--- a/pyx12/test/test_x12context.py
+++ b/pyx12/test/test_x12context.py
@@ -18,7 +18,7 @@ class X12fileTestCase(unittest.TestCase):
                 fd = StringIO(x12str)
             else:
                 fd = StringIO()
-        except:
+        except Exception:
             if x12str:
                 fd = StringIO(x12str, encoding="ascii")
             else:
@@ -551,7 +551,7 @@ class NodeDeleteSelf(X12fileTestCase):
             a = cn1.id
         except EngineError:
             pass
-        except:
+        except Exception:
             a = cn1.id
         # self.assertRaises(EngineError, cn1.id)
 

--- a/pyx12/test/test_x12file.py
+++ b/pyx12/test/test_x12file.py
@@ -34,7 +34,7 @@ class X12fileTestCase(unittest.TestCase):
                 fd = StringIO(x12str)
             else:
                 fd = StringIO()
-        except:
+        except Exception:
             if x12str:
                 fd = StringIO(x12str, encoding="ascii")
             else:

--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -18,7 +18,7 @@ class X12DocumentTestCase(unittest.TestCase):
                 fd = StringIO(x12str)
             else:
                 fd = StringIO()
-        except:
+        except Exception:
             if x12str:
                 fd = StringIO(x12str, encoding="ascii")
             else:

--- a/pyx12/test/test_xmlwriter.py
+++ b/pyx12/test/test_xmlwriter.py
@@ -18,7 +18,7 @@ class TestWriter(unittest.TestCase):
         try:
             fd = StringIO(encoding="ascii")
             # print('CASE 1:')
-        except:
+        except Exception:
             fd = StringIO()
             # print('CASE 2:')
         writer = XMLWriter(fd)
@@ -43,5 +43,5 @@ class TestWriter(unittest.TestCase):
 
         try:
             os.remove(filename)
-        except:
+        except Exception:
             pass

--- a/pyx12/test/test_xmlx12_simple.py
+++ b/pyx12/test/test_xmlx12_simple.py
@@ -26,7 +26,7 @@ class XmlTransformTestCase(unittest.TestCase):
                 fd = StringIO(x12str)
             else:
                 fd = StringIO()
-        except:
+        except Exception:
             if x12str:
                 fd = StringIO(x12str, encoding="ascii")
             else:


### PR DESCRIPTION
## Summary
- 9 bare \`except:\` clauses in test files → \`except Exception:\`
- Bare except swallows \`SystemExit\`/\`KeyboardInterrupt\`/\`BaseException\` subclasses, which test code rarely intends. Behavior unchanged for the cases these blocks were written to catch.
- Mechanical only — no logic changes, no new tests.

Files touched:
- \`test_map_if_load.py\`, \`test_rawx12file.py\`, \`test_x12context.py\` (×2), \`test_x12file.py\`, \`test_x12n_document.py\`, \`test_xmlwriter.py\` (×2), \`test_xmlx12_simple.py\`

## Future cleanup (out of scope here)
Most of these wrap a py2/3 \`StringIO(encoding=\"ascii\")\` compat fallback that is dead code on py3 — the \`except\` branch's call itself raises \`TypeError\` because \`io.StringIO\` doesn't accept \`encoding\`. The whole try/except wrapper can be removed, leaving just the if/else. Worth a follow-up PR.

## Test plan
- [x] \`pytest\` — 535 passed
- [x] \`mypy --strict\` — clean (also confirmed all remaining \`# type: ignore\` comments are load-bearing — none stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)