### PR TITLE
chore: remove stale TODO/XXX comments — now tracked as #120, #121

### DIFF
--- a/pyx12/error_999.py
+++ b/pyx12/error_999.py
@@ -343,8 +343,6 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
                 seg_data = pyx12.segment.Segment(seg_str, "~", "*", ":")
                 seg_data.set("IK304", err_cde)
                 self.wr.Write(seg_data)
-        # todo: add segment context
-        # todo: add business unit context
         if err_seg.child_err_count() > 0 and "8" not in errors:
             seg_data = pyx12.segment.Segment(seg_str, "~", "*", ":")
             seg_data.set("IK304", "8")
@@ -390,5 +388,4 @@ class error_999_visitor(pyx12.error_visitor.error_visitor):
                 seg_data.set("IK403", err_cde)
                 if bad_value:
                     seg_data.set("IK404", bad_value)
-                # todo: add element context
                 self.wr.Write(seg_data)

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -97,7 +97,6 @@ def x12n_document(
     vriic: str | None = None
     tspc: str | None = None
     cur_map: Any = None  # we do not initially know the X12 transaction type
-    # XXX Generate TA1 if needed.
 
     if fd_html:
         html = pyx12.error_html.error_html(errh, fd_html, src.get_term())
@@ -152,7 +151,6 @@ def x12n_document(
                 errh.handle_errors(src.pop_errors())
                 errh.close_isa_loop(node, seg, src)
                 # Generate 997
-                # XXX Generate TA1 if needed.
             elif seg.get_seg_id() == "GS":
                 fic = seg.get_value("GS01")
                 vriic = seg.get_value("GS08")


### PR DESCRIPTION
## Summary

Five inline TODO/XXX comments dating from 2003 (TA1 generation) and 2012 (999 IK3/IK4 context) flagged real X12 feature gaps but had sat unaddressed for 14-22 years. Code-buried comments are not a discoverable backlog — converted them to GitHub issues so they can be prioritized, owned, or closed as wontfix.

### Removed
| File | Line(s) | Comment | Age | Tracking |
|---|---|---|---|---|
| \`error_999.py\` | 346, 347 | \`# todo: add segment/business unit context\` | 14 yr | #120 |
| \`error_999.py\` | 393 | \`# todo: add element context\` | 14 yr | #120 |
| \`x12n_document.py\` | 100, 155 | \`# XXX Generate TA1 if needed.\` | 22 yr | #121 |

### Out-of-scope discovery
While doing this cleanup I noticed the \`/tech-debt\` skill's regex \`(?i)#\s*(TODO|FIXME|HACK|XXX)\b\` only matches \`#\`-prefixed comments and misses 8 more TODO mentions inside docstrings (5 in \`x12context.py\`, 1 each in \`map_walker.py\`, \`validation.py\`, plus one \`# Ugly hack\` inline marker in \`error_html.py\`). Worth a follow-up: improve the skill's pattern, then triage the rest. Not in this PR.

## Test plan
- [x] \`mypy --strict\` — clean (5 lines deleted, no logic touched)
- [x] \`pytest\` — 535 passed
- [x] Issues #120 and #121 filed and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)