### PR TITLE
refactor: drop 7 arg-type ignores via _required_attr helper

### DIFF
--- a/pyx12/error_handler.py
+++ b/pyx12/error_handler.py
@@ -15,7 +15,7 @@ Interface to X12 Errors
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 # Intrapackage imports
 import pyx12.segment
@@ -650,7 +650,7 @@ class err_gs(err_node):
         if seg_data is None:
             self.st_count_orig = 0
         else:
-            self.st_count_orig = int(seg_data.get_value("GE01"))  # type: ignore[arg-type]
+            self.st_count_orig = int(cast(str, seg_data.get_value("GE01")))
         self.st_count_recv = src.st_count  # AK903
 
     def _get_ack_code(self) -> str:

--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -35,6 +35,13 @@ from .syntax import is_syntax_valid
 MAXINT = 2147483647
 
 
+def _required_attr(elem: Element, name: str) -> str:
+    v = elem.get(name) or elem.findtext(name)
+    if v is None:
+        raise EngineError(f"Required attribute or child {name!r} missing on <{elem.tag}>")
+    return v
+
+
 class x12_node:
     """
     X12 Node Superclass
@@ -412,7 +419,7 @@ class loop_if(x12_node):
 
         self.name = elem.get("name") if elem.get("name") else elem.findtext("name")
         self.usage = elem.get("usage") if elem.get("usage") else elem.findtext("usage")
-        self.pos = int(elem.get("pos")) if elem.get("pos") else int(elem.findtext("pos"))  # type: ignore[arg-type]
+        self.pos = int(_required_attr(elem, "pos"))
         self.repeat = elem.get("repeat") if elem.get("repeat") else elem.findtext("repeat")
 
         for e in elem.findall("loop"):
@@ -703,7 +710,7 @@ class segment_if(x12_node):
 
         self.name = elem.get("name") if elem.get("name") else elem.findtext("name")
         self.usage = elem.get("usage") if elem.get("usage") else elem.findtext("usage")
-        self.pos = int(elem.get("pos")) if elem.get("pos") else int(elem.findtext("pos"))  # type: ignore[arg-type]
+        self.pos = int(_required_attr(elem, "pos"))
         self.max_use = elem.get("max_use") if elem.get("max_use") else elem.findtext("max_use")
         self.repeat = elem.get("repeat") if elem.get("repeat") else elem.findtext("repeat")
 
@@ -716,11 +723,11 @@ class segment_if(x12_node):
 
         children_map: dict[int, Element] = {}
         for e in elem.findall("element"):
-            seq = int(e.get("seq")) if e.get("seq") else int(e.findtext("seq"))  # type: ignore[arg-type]
+            seq = int(_required_attr(e, "seq"))
             children_map[seq] = e
 
         for e in elem.findall("composite"):
-            seq = int(e.get("seq")) if e.get("seq") else int(e.findtext("seq"))  # type: ignore[arg-type]
+            seq = int(_required_attr(e, "seq"))
             children_map[seq] = e
 
         for seq in sorted(children_map.keys()):
@@ -1167,7 +1174,7 @@ class element_if(x12_node):
         self.data_ele = elem.get("data_ele") if elem.get("data_ele") else elem.findtext("data_ele")
         self.usage = elem.get("usage") if elem.get("usage") else elem.findtext("usage")
         self.name = elem.get("name") if elem.get("name") else elem.findtext("name")
-        self.seq = int(elem.get("seq")) if elem.get("seq") else int(elem.findtext("seq"))  # type: ignore[arg-type]
+        self.seq = int(_required_attr(elem, "seq"))
         self.path = elem.get("seq") if elem.get("seq") else (elem.findtext("seq") or "")  # type: ignore[assignment]
         self.max_use = elem.get("max_use") if elem.get("max_use") else elem.findtext("max_use")
         self.res = elem.findtext("regex")
@@ -1529,7 +1536,7 @@ class composite_if(x12_node):
         self.refdes = elem.findtext("refdes") if elem.findtext("refdes") else self.id
         self.data_ele = elem.get("data_ele") if elem.get("data_ele") else elem.findtext("data_ele")
         self.usage = elem.get("usage") if elem.get("usage") else elem.findtext("usage")
-        self.seq = int(elem.get("seq")) if elem.get("seq") else int(elem.findtext("seq"))  # type: ignore[arg-type]
+        self.seq = int(_required_attr(elem, "seq"))
         if (r := elem.get("repeat")) is not None:
             self.repeat = int(r)
         elif (r := elem.findtext("repeat")) is not None:


### PR DESCRIPTION
## Summary

Extracted a small private helper \`_required_attr(elem, name)\` in \`map_if.py\` that consolidates the repeated pattern:

\`\`\`python
int(elem.get(K)) if elem.get(K) else int(elem.findtext(K))  # type: ignore[arg-type]
\`\`\`

into a single lookup that raises \`EngineError\` when neither attribute nor child element yields a value. Six map_if.py sites collapse to a one-liner each, dropping six \`# type: ignore[arg-type]\` suppressions.

Also refactored the lone \`error_handler.py:653\` ignore (\`int(seg_data.get_value(\"GE01\"))\`) to use \`cast(str, ...)\` — preserves the original crash-on-missing-GE01 semantics, just without the suppression.

### Sites refactored
| File | Lines | Field |
|---|---|---|
| \`map_if.py\` | 415, 706 | segment/loop \`pos\` |
| \`map_if.py\` | 719, 723 | child \`seq\` (elements/composites) |
| \`map_if.py\` | 1170, 1532 | element \`seq\` |
| \`error_handler.py\` | 653 | GE01 transaction count |

### Why a helper, not walrus
The walrus pattern from #118 worked there because \`repeat\` had a natural default of 1. Here \`pos\` and \`seq\` are required positional indices — no sane default. With six identical sites, a helper is well past CLAUDE.md's "three similar lines beats a premature helper" threshold.

### Side benefit
Each refactored site previously made up to four redundant XML lookups (\`elem.get\` twice, \`elem.findtext\` twice). Now exactly one of each in the helper.

## Test plan
- [x] \`mypy --strict\` — clean
- [x] \`pytest\` — 535 passed
- [x] \`ruff format --check\` + \`ruff check --select I\` — clean
- [x] Total \`# type: ignore\` count: 48 → 41 (-7)

## Out of scope (remaining arg-type ignores)
After this PR, the remaining arg-type ignores cluster around different patterns that need different fixes:
- \`x12file.py\` (×8) — Segment terminator passing (\`str | None\` → \`str\`)
- \`xmlx12_simple.py\` (×2) — \`node.text\` (\`str | None\`) passed to \`Segment.set\`
- \`errh_xml.py\` (×1) — \`XMLWriter\` arg
- \`x12context.py\` (×1) — intentionally type-mismatched \`push_loops\` (kept by design, see code comment)

Could be a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)