### PR TITLE
refactor: drop all no-any-return ignores

### DIFF
--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -18,7 +18,7 @@ import re
 import sys
 from collections.abc import Iterator
 from importlib.resources import files as _res_files
-from typing import IO, Any
+from typing import IO, Any, cast
 from xml.etree.ElementTree import Element
 
 import defusedxml.ElementTree as et
@@ -68,12 +68,6 @@ class x12_node:
         if isinstance(other, x12_node):
             return self.id == other.id and self.parent.id == other.parent.id
         return NotImplemented
-
-    def __ne__(self, other: object) -> bool:
-        res = type(self).__eq__(self, other)
-        if res is NotImplemented:
-            return res  # type: ignore[no-any-return]
-        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented
@@ -255,8 +249,7 @@ class map_if(x12_node):
         ipath = "/ISA_LOOP/ISA"
         try:
             node = self.getnodebypath(ipath).children[11]
-            icvn = node.valid_codes[0]
-            return icvn  # type: ignore[no-any-return]
+            return cast(str, node.valid_codes[0])
         except Exception:
             return None
 

--- a/pyx12/path.py
+++ b/pyx12/path.py
@@ -152,12 +152,6 @@ class X12Path:
             )
         return NotImplemented
 
-    def __ne__(self, other: object) -> bool:
-        res = type(self).__eq__(self, other)
-        if res is NotImplemented:
-            return res  # type: ignore[no-any-return]
-        return not bool(res)
-
     def __lt__(self, other: object) -> bool:
         return NotImplemented
 

--- a/pyx12/segment.py
+++ b/pyx12/segment.py
@@ -50,12 +50,6 @@ class Element:
             return self.value == other.value
         return NotImplemented
 
-    def __ne__(self, other: object) -> bool:
-        res = type(self).__eq__(self, other)
-        if res is NotImplemented:
-            return res  # type: ignore[no-any-return]
-        return not bool(res)
-
     def __lt__(self, other: object) -> bool:
         return NotImplemented
 
@@ -158,12 +152,6 @@ class Composite:
                     return False
             return True
         return NotImplemented
-
-    def __ne__(self, other: object) -> bool:
-        res = type(self).__eq__(self, other)
-        if res is NotImplemented:
-            return res  # type: ignore[no-any-return]
-        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented
@@ -326,12 +314,6 @@ class Segment:
                     return False
             return True
         return NotImplemented
-
-    def __ne__(self, other: object) -> bool:
-        res = type(self).__eq__(self, other)
-        if res is NotImplemented:
-            return res  # type: ignore[no-any-return]
-        return not bool(res)
 
     def __lt__(self, other: object) -> bool:
         return NotImplemented


### PR DESCRIPTION
## Summary

Eliminates the entire \`no-any-return\` category of \`# type: ignore\` suppressions (6 → 0).

### Five identical \`__ne__\` methods deleted
\`map_if.py\`, \`segment.py\` (×3), \`path.py\` each had this exact method:

\`\`\`python
def __ne__(self, other: object) -> bool:
    res = type(self).__eq__(self, other)
    if res is NotImplemented:
        return res  # type: ignore[no-any-return]
    return not bool(res)
\`\`\`

This duplicates Python's default \`object.__ne__\` line-for-line: invoke \`__eq__\`, return \`NotImplemented\` if it does, otherwise negate. Each class still defines \`__eq__\`, so the Python default takes over with **identical behavior** and no type-ignore noise.

### One cast
\`map_if.py:259\` returned \`node.valid_codes[0]\` from a deeply nested dynamic attribute lookup (mypy widens to \`Any\`). Replaced with \`cast(str, ...)\` — preserves semantics, drops the suppression.

## Net effect

| | Before | After |
|---|---|---|
| \`no-any-return\` ignores | 6 | **0** |
| Total \`# type: ignore\` count | 41 | 35 |
| Lines | — | -31 |

## Test plan
- [x] \`mypy --strict\` — clean
- [x] \`pytest\` — 535 passed
- [x] \`ruff format --check\` + \`ruff check --select I\` — clean
- [x] \`__eq__\` and \`!=\` semantics covered by existing equality tests in \`test_segment.py\`, \`test_map_if.py\`, \`test_path.py\` — all pass

## Side observation (out of scope)
\`segment.py\` lines 171-172 have a duplicated \`__le__ = __lt__\` (typo — same assignment twice). Not touched here; worth a 1-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)