### PR TITLE
fix: guard composite_if against None comp_data (#74)

### DIFF
--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -1590,10 +1590,11 @@ class composite_if(x12_node):
 
         if self.usage == "R":
             good_flag = False
-            for sub_ele in comp_data:
-                if sub_ele is not None and len(sub_ele.get_value()) > 0:
-                    good_flag = True
-                    break
+            if comp_data is not None:
+                for sub_ele in comp_data:
+                    if sub_ele is not None and len(sub_ele.get_value()) > 0:
+                        good_flag = True
+                        break
             if not good_flag:
                 err_str = 'At least one component of composite "%s" (%s) is required' % (
                     self.name,

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -813,3 +813,29 @@ class GetCompositeNodeByPath(unittest.TestCase):
         self.assertEqual(
             newnode.get_path(), "/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC01-01"
         )
+
+
+class CompositeRequiredMissing(unittest.TestCase):
+    """Regression for issue #74.
+
+    When a required composite element is entirely absent from a segment,
+    `composite_if.is_valid` was iterating its `None` data and raising
+    `TypeError: 'NoneType' object is not iterable`. After the fix it
+    should fail validation cleanly — segment-level validation flags the
+    missing required element with err_cde "1".
+    """
+
+    def setUp(self):
+        param = pyx12.params.params()
+        self.map = pyx12.map_if.load_map_file("835.5010.X221.A1.xml", param)
+        self.node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/FOOTER/PLB")
+        self.errh = pyx12.error_handler.errh_null()
+
+    def test_plb03_composite_missing(self):
+        # PLB03 is the required Adjustment Identifier composite. Here the
+        # whole element is omitted from the segment.
+        self.errh.err_cde = None
+        seg_data = pyx12.segment.Segment("PLB*123*20211108~", "~", "*", ":")
+        result = self.node.is_valid(seg_data, self.errh)
+        self.assertFalse(result)
+        self.assertEqual(self.errh.err_cde, "1")


### PR DESCRIPTION
Closes #74.

## Summary

When a segment omits a required composite element entirely, the parent validator passes \`None\` as \`comp_data\` to \`composite_if.is_valid\`. The early-return at line 1588 only handled None for usage \`\"N\"\`/\`\"S\"\`; the usage \`\"R\"\` branch fell through to \`for sub_ele in comp_data:\` and crashed with \`TypeError: 'NoneType' object is not iterable\`. Bug originally reported in 2021 — has sat unfixed since.

## The fix

Three-line guard around the \`for\` loop in the \`usage == \"R\"\` branch:

\`\`\`python
if self.usage == \"R\":
    good_flag = False
    if comp_data is not None:        # ← new
        for sub_ele in comp_data:
            ...
    if not good_flag:
        ...
        return False
\`\`\`

When \`comp_data is None\`, the loop is skipped, \`good_flag\` stays \`False\`, and the existing \"at least one component required\" error path fires correctly. Same outcome as for an empty composite.

## Tests

Added a regression test (\`CompositeRequiredMissing.test_plb03_composite_missing\`) using the exact reporter repro: \`PLB*123*20211108~\` against the \`835.5010.X221.A1\` map, where PLB03 is a required composite.

Two-commit history makes the bug-then-fix flow inspectable:
- [\`07390b1\`](../commit/07390b1) — failing regression test (red)
- [\`9a55436\`](../commit/9a55436) — fix (green)

You can verify by checking out the test commit alone and running it — it fails with the original TypeError at \`map_if.py:1593\`.

## Test plan
- [x] New test passes after fix
- [x] Full suite: 536 passed (was 535 + 1 new)
- [x] \`mypy --strict\` — clean
- [x] \`ruff format --check\` + \`ruff check --select I\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)