### PR TITLE
chore: log says package resources not pkg_resources (closes #51)

### DIFF
--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -1654,7 +1654,7 @@ def load_map_file(map_file: str, param: Any, map_path: str | None = None) -> map
             )
         map_fd = open(full_path, encoding="utf-8")
     else:
-        logger.debug("Looking for map file '{}' in pkg_resources".format(map_file))
+        logger.debug("Looking for map file '{}' in package resources".format(map_file))
         map_fd = _res_files("pyx12").joinpath("map", map_file).open("rb")
     with map_fd:
         logger.debug("Create map from %s" % (map_file))


### PR DESCRIPTION
Closes #51.

## Summary

The technical migration from \`pkg_resources\` / \`pkgutil\` to \`importlib.resources\` (the original ask in #51) was completed some time ago — every package-resource load in the codebase already uses \`importlib.resources.files\`:

| File | Use |
|---|---|
| \`codes.py\`, \`dataele.py\`, \`map_if.py\`, \`map_index.py\` | \`_res_files(\"pyx12\").joinpath(\"map\", file).open(\"rb\")\` |

Grep for \`pkg_resources\` or \`pkgutil\` imports across the codebase: zero hits.

The only remaining text reference was a stale debug-log string in \`map_if.py:1657\`:

\`\`\`python
logger.debug(\"Looking for map file '{}' in pkg_resources\".format(map_file))
\`\`\`

— with the line right below it actually loading via \`_res_files\`. This PR just brings the log message in line with reality.

## Test plan
- [x] \`pytest\` — 536 passed
- [x] No production behavior changes (debug-log text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)