### PR TITLE
refactor: extract _resolve_unique_key_field for segment matching (2/5)

### DIFF
--- a/pyx12/map_if.py
+++ b/pyx12/map_if.py
@@ -816,51 +816,14 @@ class segment_if(x12_node):
         :return: boolean
         :rtype: boolean
         """
-        if seg.get_seg_id() == self.id:
-            if (
-                self.children[0].is_element()
-                and self.children[0].get_data_type() == "ID"
-                and self.children[0].usage == "R"
-                and len(self.children[0].valid_codes) > 0
-                and seg.get_value("01") not in self.children[0].valid_codes
-            ):
-                return False
-            # Special Case for 820
-            elif (
-                seg.get_seg_id() == "ENT"
-                and self.children[1].is_element()
-                and self.children[1].get_data_type() == "ID"
-                and len(self.children[1].valid_codes) > 0
-                and seg.get_value("02") not in self.children[1].valid_codes
-            ):
-                return False
-            # Special Case for 999 CTX
-            elif (
-                seg.get_seg_id() == "CTX"
-                and self.children[0].is_composite()
-                and self.children[0].children[0].get_data_type() == "AN"
-                and len(self.children[0].children[0].valid_codes) > 0
-                and seg.get_value("01-1") not in self.children[0].children[0].valid_codes
-            ):
-                return False
-            elif (
-                self.children[0].is_composite()
-                and self.children[0].children[0].get_data_type() == "ID"
-                and len(self.children[0].children[0].valid_codes) > 0
-                and seg.get_value("01-1") not in self.children[0].children[0].valid_codes
-            ):
-                return False
-            elif (
-                seg.get_seg_id() == "HL"
-                and self.children[2].is_element()
-                and len(self.children[2].valid_codes) > 0
-                and seg.get_value("03") not in self.children[2].valid_codes
-            ):
-                return False
-            else:
-                return True
-        else:
+        if seg.get_seg_id() != self.id:
             return False
+        key = self._resolve_unique_key_field(seg.get_seg_id(), with_qual=False)
+        if key is None:
+            return True
+        child, ele_idx, subele_idx = key
+        path = f"{ele_idx:02d}-{subele_idx}" if subele_idx else f"{ele_idx:02d}"
+        return seg.get_value(path) in child.valid_codes
 
     def is_match_qual(
         self,
@@ -877,64 +840,74 @@ class segment_if(x12_node):
         :return: (True if a match, qual_code, element_index, subelement_index)
         :rtype: tuple(boolean, string, int, int)
         """
-        if seg_id == self.id:
-            if qual_code is None:
-                return (True, None, None, None)
-            elif (
-                self.children[0].is_element()
-                and self.children[0].get_data_type() == "ID"
-                and self.children[0].usage == "R"
-                and len(self.children[0].valid_codes) > 0
-            ):
-                if (
-                    qual_code in self.children[0].valid_codes
-                    and seg_data.get_value("01") == qual_code
-                ):
-                    return (True, qual_code, 1, None)
-                else:
-                    return (False, None, None, None)
-            # Special Case for 820
-            elif (
-                seg_id == "ENT"
-                and self.children[1].is_element()
-                and self.children[1].get_data_type() == "ID"
-                and len(self.children[1].valid_codes) > 0
-            ):
-                if (
-                    qual_code in self.children[1].valid_codes
-                    and seg_data.get_value("02") == qual_code
-                ):
-                    return (True, qual_code, 2, None)
-                else:
-                    return (False, None, None, None)
-            elif (
-                self.children[0].is_composite()
-                and self.children[0].children[0].get_data_type() == "ID"
-                and len(self.children[0].children[0].valid_codes) > 0
-            ):
-                if (
-                    qual_code in self.children[0].children[0].valid_codes
-                    and seg_data.get_value("01-1") == qual_code
-                ):
-                    return (True, qual_code, 1, 1)
-                else:
-                    return (False, None, None, None)
-            elif (
-                seg_id == "HL"
-                and self.children[2].is_element()
-                and len(self.children[2].valid_codes) > 0
-            ):
-                if (
-                    qual_code in self.children[2].valid_codes
-                    and seg_data.get_value("03") == qual_code
-                ):
-                    return (True, qual_code, 3, None)
-                else:
-                    return (False, None, None, None)
-            else:
-                return (True, None, None, None)
-        else:
+        if seg_id != self.id:
             return (False, None, None, None)
+        if qual_code is None:
+            return (True, None, None, None)
+        key = self._resolve_unique_key_field(seg_id, with_qual=True)
+        if key is None:
+            return (True, None, None, None)
+        child, ele_idx, subele_idx = key
+        path = f"{ele_idx:02d}-{subele_idx}" if subele_idx else f"{ele_idx:02d}"
+        if qual_code in child.valid_codes and seg_data.get_value(path) == qual_code:
+            return (True, qual_code, ele_idx, subele_idx)
+        return (False, None, None, None)
+
+    def _resolve_unique_key_field(
+        self, seg_id: str | None, *, with_qual: bool
+    ) -> tuple[Any, int, int | None] | None:
+        """
+        Locate the child node carrying this segment's qualifier (if any).
+
+        Returns ``(validating_child, ele_idx, subele_idx_or_None)`` describing
+        where to read the qualifier value from a data segment, or ``None`` if
+        the segment has no recognizable qualifier field.
+
+        ``with_qual=False`` (used by ``is_match``) accepts the AN-typed CTX
+        composite as a valid qualifier carrier; ``with_qual=True`` (used by
+        ``is_match_qual``) only honors ID-typed qualifier fields.
+        """
+        # Element at position 01 — the common case
+        if (
+            self.children[0].is_element()
+            and self.children[0].get_data_type() == "ID"
+            and self.children[0].usage == "R"
+            and len(self.children[0].valid_codes) > 0
+        ):
+            return (self.children[0], 1, None)
+        # ENT-segment carries its qualifier at element 02 (820 special case)
+        if (
+            seg_id == "ENT"
+            and self.children[1].is_element()
+            and self.children[1].get_data_type() == "ID"
+            and len(self.children[1].valid_codes) > 0
+        ):
+            return (self.children[1], 2, None)
+        # CTX-segment can have an AN-typed composite at 01-1 (999 special case);
+        # is_match_qual ignores this branch.
+        if (
+            not with_qual
+            and seg_id == "CTX"
+            and self.children[0].is_composite()
+            and self.children[0].children[0].get_data_type() == "AN"
+            and len(self.children[0].children[0].valid_codes) > 0
+        ):
+            return (self.children[0].children[0], 1, 1)
+        # General ID-typed composite at 01-1
+        if (
+            self.children[0].is_composite()
+            and self.children[0].children[0].get_data_type() == "ID"
+            and len(self.children[0].children[0].valid_codes) > 0
+        ):
+            return (self.children[0].children[0], 1, 1)
+        # HL-segment carries its qualifier at element 03
+        if (
+            seg_id == "HL"
+            and self.children[2].is_element()
+            and len(self.children[2].valid_codes) > 0
+        ):
+            return (self.children[2], 3, None)
+        return None
 
     def guess_unique_key_id_element(self) -> Any:
         """


### PR DESCRIPTION
Second of 5 PRs in the [map_if refactor plan](C:\Users\john\.claude\plans\starry-watching-sketch.md). Internal cleanup, no public API or behavior change.

## Summary

\`segment_if.is_match\` (52 lines) and \`is_match_qual\` (73 lines) shared the same five-branch cascade for locating the segment's qualifier-bearing child. Extracted that cascade into a single \`_resolve_unique_key_field\` helper. Each caller is now ~14 lines.

### The five branches (all preserved exactly)
| | Where the qualifier lives | Restriction |
|---|---|---|
| 1 | Element at \`01\`, type ID, \`usage=R\`, valid_codes set | (the common case) |
| 2 | Element at \`02\`, type ID, valid_codes set | seg_id == \"ENT\" (820) |
| 3 | Composite at \`01-1\`, type **AN**, valid_codes set | seg_id == \"CTX\" (999) — \`is_match\` only |
| 4 | Composite at \`01-1\`, type **ID**, valid_codes set | (general) |
| 5 | Element at \`03\`, valid_codes set | seg_id == \"HL\" |

### How the helper differs per caller
- \`is_match\` (returns \`bool\`) — builds path \`\"01\"\`/\`\"02\"\`/\`\"03\"\`/\`\"01-1\"\` from indices, checks \`seg.get_value(path) in child.valid_codes\`
- \`is_match_qual\` (returns \`tuple[bool, str|None, int|None, int|None]\`) — same path lookup, additionally requires \`qual_code in valid_codes\` *and* \`seg.get_value(path) == qual_code\`, returns position-tagged tuple

### The lone behavioral difference
The CTX/AN composite branch (case 3) is *only* honored by \`is_match\`. \`is_match_qual\` falls through CTX-with-AN to its general ID-composite branch, which doesn't match (data type mismatch), so it returns \`(True, None, None, None)\` — exactly as before. Modeled with a \`with_qual\` flag on the helper.

## Diff
74 insertions, 101 deletions, **net -27 lines**.

## Test plan
- [x] \`pytest\` — 536 passed (test_map_walker.py is the safety net for segment matching, 1088 lines)
- [x] \`mypy --strict\` — clean
- [x] \`ruff format --check\` + \`ruff check --select I\` — clean
- [x] No public API change

## Up next
- PR 3: convert \`map_if.py\` → \`pyx12/map_if/\` package, move \`x12_node\` + \`_required_attr\` to \`_base.py\`
- PR 4: move \`loop_if\`, \`composite_if\`, \`element_if\`
- PR 5: move \`segment_if\`, \`map_if\`, \`load_map_file\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)