### PR TITLE
refactor: convert map_if.py to a package; move x12_node to _base (3/5)

### DIFF
--- a/pyx12.pyproj
+++ b/pyx12.pyproj
@@ -69,7 +69,8 @@
     <Compile Include="pyx12\error_html.py" />
     <Compile Include="pyx12\error_item.py" />
     <Compile Include="pyx12\error_visitor.py" />
-    <Compile Include="pyx12\map_if.py" />
+    <Compile Include="pyx12\map_if\__init__.py" />
+    <Compile Include="pyx12\map_if\_base.py" />
     <Compile Include="pyx12\map_index.py" />
     <Compile Include="pyx12\map_override.py" />
     <Compile Include="pyx12\map_walker.py" />

--- a/pyx12/map_if/__init__.py
+++ b/pyx12/map_if/__init__.py
@@ -26,173 +26,15 @@ import defusedxml.ElementTree as et
 # Intrapackage imports
 import pyx12.segment
 
-from . import codes, dataele, validation
-from . import path as _path
-from .dataele import _DataEle
-from .errors import EngineError
-from .path import X12Path
-from .syntax import is_syntax_valid
-
-MAXINT = 2147483647
-
-
-def _required_attr(elem: Element, name: str) -> str:
-    v = elem.get(name) or elem.findtext(name)
-    if v is None:
-        raise EngineError(f"Required attribute or child {name!r} missing on <{elem.tag}>")
-    return v
+from .. import codes, dataele, validation
+from .. import path as _path
+from ..dataele import _DataEle
+from ..errors import EngineError
+from ..path import X12Path
+from ..syntax import is_syntax_valid
+from ._base import MAXINT, _required_attr, x12_node
 
 
-class x12_node:
-    """
-    X12 Node Superclass
-    """
-
-    id: str | None
-    name: str | None
-    parent: Any
-    children: list[Any]
-    path: str
-    _x12path: X12Path | None
-    _fullpath: str | None
-
-    def __init__(self) -> None:
-        self.id = None
-        self.name = None
-        self.parent = None
-        self.children = []
-        self.path = ""
-        self._x12path = None
-        self._fullpath = None
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, x12_node):
-            return self.id == other.id and self.parent.id == other.parent.id
-        return NotImplemented
-
-    def __lt__(self, other: object) -> bool:
-        return NotImplemented
-
-    __le__ = __lt__
-    __le__ = __lt__
-    __gt__ = __lt__
-    __ge__ = __lt__
-
-    def __hash__(self) -> int:
-        return ((self.id or "") + (self.parent.id or "")).__hash__()
-
-    def __len__(self) -> int:
-        return len(self.children)
-
-    def __repr__(self) -> str:
-        """
-        :rtype: string
-        """
-        return self.name or ""
-
-    def getnodebypath(self, path: str) -> Any:
-        """ """
-        pathl = path.split("/")
-        if len(pathl) == 0:
-            return None
-        for child in self.children:
-            if child.id.lower() == pathl[0].lower():
-                if len(pathl) == 1:
-                    return child
-                else:
-                    if child.is_loop():
-                        return child.getnodebypath("/".join(pathl[1:]))
-                    else:
-                        break
-        raise EngineError('getnodebypath failed. Path "%s" not found' % path)
-
-    def get_child_count(self) -> int:
-        return len(self.children)
-
-    def get_child_node_by_idx(self, idx: int) -> Any:
-        """
-        :param idx: zero based
-        """
-        if idx >= len(self.children):
-            return None
-        else:
-            return self.children[idx]
-
-    def get_child_node_by_ordinal(self, ordinal: int) -> Any:
-        """
-        Get a child element or composite by the X12 ordinal
-        :param ord: one based element/composite index.  Corresponds to the map <seq> element
-        :type ord: int
-        """
-        return self.get_child_node_by_idx(ordinal - 1)
-
-    def get_path(self) -> str:
-        """
-        :return: path - XPath style
-        :rtype: string
-        """
-        if self._fullpath:
-            return self._fullpath
-        parent_path = self.parent.get_path()
-        if parent_path == "/":
-            self._fullpath = "/" + self.path
-            return self._fullpath
-        else:
-            self._fullpath = parent_path + "/" + self.path
-            return self._fullpath
-
-    def _get_x12_path(self) -> X12Path:
-        """
-        :return: X12 node path
-        :rtype: L{path<X12Path>}
-        """
-        if self._x12path:
-            return self._x12path
-        p = X12Path(self.get_path())
-        self._x12path = p
-        return p
-
-    x12path = property(_get_x12_path, None, None)
-
-    def is_first_seg_in_loop(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-    def is_map_root(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-    def is_loop(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-    def is_segment(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-    def is_element(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-    def is_composite(self) -> bool:
-        """
-        :rtype: boolean
-        """
-        return False
-
-
-############################################################
-# Map file interface
 ############################################################
 class map_if(x12_node):
     """
@@ -1631,3 +1473,16 @@ def load_map_file(map_file: str, param: Any, map_path: str | None = None) -> map
         parser = et.XMLParser(encoding="utf-8")
         etree = et.parse(map_fd, parser=parser)
         return map_if(etree.getroot(), param, map_path)
+
+
+__all__ = [
+    "MAXINT",
+    "_required_attr",
+    "x12_node",
+    "map_if",
+    "loop_if",
+    "segment_if",
+    "element_if",
+    "composite_if",
+    "load_map_file",
+]

--- a/pyx12/map_if/_base.py
+++ b/pyx12/map_if/_base.py
@@ -1,0 +1,180 @@
+######################################################################
+# Copyright (c)
+# All rights reserved.
+#
+# This software is licensed as described in the file LICENSE.txt, which
+# you should have received as part of this distribution.
+#
+######################################################################
+"""
+Base node and shared helpers for the X12N IG map interface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from xml.etree.ElementTree import Element
+
+from ..errors import EngineError
+from ..path import X12Path
+
+MAXINT = 2147483647
+
+
+def _required_attr(elem: Element, name: str) -> str:
+    v = elem.get(name) or elem.findtext(name)
+    if v is None:
+        raise EngineError(f"Required attribute or child {name!r} missing on <{elem.tag}>")
+    return v
+
+
+class x12_node:
+    """
+    X12 Node Superclass
+    """
+
+    id: str | None
+    name: str | None
+    parent: Any
+    children: list[Any]
+    path: str
+    _x12path: X12Path | None
+    _fullpath: str | None
+
+    def __init__(self) -> None:
+        self.id = None
+        self.name = None
+        self.parent = None
+        self.children = []
+        self.path = ""
+        self._x12path = None
+        self._fullpath = None
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, x12_node):
+            return self.id == other.id and self.parent.id == other.parent.id
+        return NotImplemented
+
+    def __lt__(self, other: object) -> bool:
+        return NotImplemented
+
+    __le__ = __lt__
+    __le__ = __lt__
+    __gt__ = __lt__
+    __ge__ = __lt__
+
+    def __hash__(self) -> int:
+        return ((self.id or "") + (self.parent.id or "")).__hash__()
+
+    def __len__(self) -> int:
+        return len(self.children)
+
+    def __repr__(self) -> str:
+        """
+        :rtype: string
+        """
+        return self.name or ""
+
+    def getnodebypath(self, path: str) -> Any:
+        """ """
+        pathl = path.split("/")
+        if len(pathl) == 0:
+            return None
+        for child in self.children:
+            if child.id.lower() == pathl[0].lower():
+                if len(pathl) == 1:
+                    return child
+                else:
+                    if child.is_loop():
+                        return child.getnodebypath("/".join(pathl[1:]))
+                    else:
+                        break
+        raise EngineError('getnodebypath failed. Path "%s" not found' % path)
+
+    def get_child_count(self) -> int:
+        return len(self.children)
+
+    def get_child_node_by_idx(self, idx: int) -> Any:
+        """
+        :param idx: zero based
+        """
+        if idx >= len(self.children):
+            return None
+        else:
+            return self.children[idx]
+
+    def get_child_node_by_ordinal(self, ordinal: int) -> Any:
+        """
+        Get a child element or composite by the X12 ordinal
+        :param ord: one based element/composite index.  Corresponds to the map <seq> element
+        :type ord: int
+        """
+        return self.get_child_node_by_idx(ordinal - 1)
+
+    def get_path(self) -> str:
+        """
+        :return: path - XPath style
+        :rtype: string
+        """
+        if self._fullpath:
+            return self._fullpath
+        parent_path = self.parent.get_path()
+        if parent_path == "/":
+            self._fullpath = "/" + self.path
+            return self._fullpath
+        else:
+            self._fullpath = parent_path + "/" + self.path
+            return self._fullpath
+
+    def _get_x12_path(self) -> X12Path:
+        """
+        :return: X12 node path
+        :rtype: L{path<X12Path>}
+        """
+        if self._x12path:
+            return self._x12path
+        p = X12Path(self.get_path())
+        self._x12path = p
+        return p
+
+    x12path = property(_get_x12_path, None, None)
+
+    def is_first_seg_in_loop(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+    def is_map_root(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+    def is_loop(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+    def is_segment(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+    def is_element(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+    def is_composite(self) -> bool:
+        """
+        :rtype: boolean
+        """
+        return False
+
+
+############################################################
+# Map file interface


### PR DESCRIPTION
Third of 5 PRs in the [map_if refactor plan](C:\Users\john\.claude\plans\starry-watching-sketch.md). **Mechanical only** — identical runtime behavior, identical public surface, identical class definitions. Just file layout.

## Summary

\`pyx12/map_if.py\` (1633 lines) becomes a package directory. The lone class \`x12_node\` plus the \`_required_attr\` helper and the \`MAXINT\` constant move into \`pyx12/map_if/_base.py\` (~200 lines). Everything else stays inline in \`pyx12/map_if/__init__.py\` for now — PRs 4 and 5 will move them to sibling files.

## Layout change

\`\`\`
pyx12/map_if.py
   ↓
pyx12/map_if/__init__.py     (the rest, with `from ..X` instead of `from .X`)
pyx12/map_if/_base.py        (x12_node + _required_attr + MAXINT)
\`\`\`

Git detected the rename: \`map_if.py → map_if/__init__.py\` reports as 92% similar, so blame history continues at the destination.

## Why _base.py is the right first move
\`x12_node\` is the smallest, most self-contained class (no inward dependencies on its siblings). The \`_required_attr\` helper is used by 4 of 5 node \`__init__\` methods to parse XML attrs — it's a node-construction helper, so it lives next to the base node. This validates the package-shim mechanic before the larger moves in PR 4 and PR 5.

## Backward-compat invariant
External code does \`import pyx12.map_if\` and accesses the symbols via attribute or \`from pyx12.map_if import X\`. The package's \`__init__.py\` re-exports everything that was previously top-level — verified locally:

\`\`\`bash
.venv/Scripts/python -c \"
import pyx12.map_if
assert all(hasattr(pyx12.map_if, n) for n in [
    'load_map_file', 'map_if', 'x12_node', 'loop_if',
    'segment_if', 'element_if', 'composite_if',
    '_required_attr', 'MAXINT'
])
\"
\`\`\`

\`__all__\` declared at the bottom of \`__init__.py\` for explicitness.

## pyx12.pyproj
The Visual Studio project file's \`<Compile Include=\"pyx12\map_if.py\" />\` line is replaced with two entries for the new package files.

## Verification
| Gate | Result |
|---|---|
| \`pytest\` | 536 passed |
| \`mypy --strict\` | clean (76 source files now, was 75) |
| \`ruff format --check\` | clean |
| \`ruff check --select I\` | clean |
| Import smoke test | all 9 names resolvable from \`pyx12.map_if\` |

## Up next
- PR 4: move \`loop_if\`, \`composite_if\`, \`element_if\` to sibling \`_loop.py\` / \`_composite.py\` / \`_element.py\`
- PR 5: move \`segment_if\`, \`map_if\`, \`load_map_file\` to \`_segment.py\` / \`_root.py\` / \`_loader.py\`; \`__init__.py\` becomes a thin re-export shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)