### PR TITLE
chore: enable ruff UP rules; modernize 137 sites via autofix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,11 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["F", "I", "B904"]
+select = ["F", "I", "UP", "B904"]
+# UP031 (printf-string-formatting) is opted out: the project's `%`-format
+# strings format integers (line numbers, counts, codes) where ruff can't
+# guarantee a safe f-string conversion. Defer as a separate manual sweep.
+ignore = ["UP031"]
 
 # Test, examples, scripts, and map-generation helpers are loose with locals
 # (assignment-only stubs, *-imports, undefined names tolerated for clarity).

--- a/pyx12/error_debug.py
+++ b/pyx12/error_debug.py
@@ -62,7 +62,7 @@ class error_debug_visitor(error_visitor):
             self.fd.write("  %s %s\n" % err)
         for ele in err_isa.elements:
             self.fd.write("  %s %s\n" % (ele.id, ele.name))
-            print((ele.parent))
+            print(ele.parent)
             for err in ele.errors:
                 self.fd.write("    ERR %s %s (%s)\n" % err)
 

--- a/pyx12/error_handler.py
+++ b/pyx12/error_handler.py
@@ -378,8 +378,7 @@ class err_handler:
         """
         Return the next error node
         """
-        for child in self.children:
-            yield child
+        yield from self.children
 
     def is_closed(self) -> bool:
         """
@@ -568,8 +567,7 @@ class err_isa(err_node):
         """
         Return the next error node
         """
-        for child in self.children:
-            yield child
+        yield from self.children
         next(self.parent)
 
     def __repr__(self) -> str:
@@ -709,8 +707,7 @@ class err_gs(err_node):
         """
         Return the next error node
         """
-        for child in self.children:
-            yield child
+        yield from self.children
         next(self.parent)
 
     def __repr__(self) -> str:
@@ -845,8 +842,7 @@ class err_st(err_node):
         """
         Return the next error node
         """
-        for child in self.children:
-            yield child
+        yield from self.children
         return
 
     def __repr__(self) -> str:

--- a/pyx12/examples/deident834.py
+++ b/pyx12/examples/deident834.py
@@ -70,15 +70,15 @@ class RandomDeidentify:
         if primaryId in self.identities:
             return self.identities[primaryId]
         demo = Demographic(
-            primaryId="{0:0>10}".format(random.randint(1000, 99999999999)),
-            ssn="{0:0>9}".format(random.randint(10000, 999999999)),
-            medicaidId="{0:0>10}".format(random.randint(1000, 99999999999)),
+            primaryId=f"{random.randint(1000, 99999999999):0>10}",
+            ssn=f"{random.randint(10000, 999999999):0>9}",
+            medicaidId=f"{random.randint(1000, 99999999999):0>10}",
             dob="19520101",
             dod="",
             firstname="AA",
             lastname="Smith",
             middlename="",
-            street="{0} Oak".format(random.randint(10, 9999)),
+            street=f"{random.randint(10, 9999)} Oak",
             street2="",
             county="98",
         )
@@ -101,7 +101,7 @@ def deidentify_file(fd_in):
                 scrub2000(datatree, deident)
             for seg1 in datatree.iterate_segments():
                 # wr.Write(seg1['segment'].format())
-                print((seg1["segment"].format()))
+                print(seg1["segment"].format())
 
 
 def scrub2000(loop_sub, deident):
@@ -157,7 +157,7 @@ def main():
             usage()
             return False
         # file_name = os.path.basename(file_in)
-        fd_in = open(file_in, "r", encoding="ascii")
+        fd_in = open(file_in, encoding="ascii")
         deidentify_file(fd_in)
     return True
 

--- a/pyx12/examples/generate_spec.py
+++ b/pyx12/examples/generate_spec.py
@@ -19,16 +19,12 @@ def clean_name(name):
 
 def check_map_path_arg(map_path):
     if not os.path.isdir(map_path):
-        raise argparse.ArgumentError(
-            None, "The MAP_PATH '{}' is not a valid directory".format(map_path)
-        )
+        raise argparse.ArgumentError(None, f"The MAP_PATH '{map_path}' is not a valid directory")
     index_file = "maps.xml"
     if not os.path.isfile(os.path.join(map_path, index_file)):
         raise argparse.ArgumentError(
             None,
-            "The MAP_PATH '{}' does not contain the map index file '{}'".format(
-                map_path, index_file
-            ),
+            f"The MAP_PATH '{map_path}' does not contain the map index file '{index_file}'",
         )
     return map_path
 
@@ -70,7 +66,7 @@ def save_mapping(rows, json_file):
     with open(json_file, "w") as fd:
         fd.write("{")
         for s in sections:
-            fd.write('"{section}": ['.format(section=s))
+            fd.write(f'"{s}": [')
             s = [
                 {
                     "Id": x["Id"],
@@ -90,7 +86,7 @@ def save_mapping(rows, json_file):
             s.sort(key=lambda item: item["Ordinal"])
             for item in s:
                 fitem = json.dumps(item)
-                fd.write("\n\t{item},".format(item=fitem))
+                fd.write(f"\n\t{fitem},")
             fd.write("\n],\n")
         fd.write("}")
 
@@ -166,7 +162,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="{prog} {version}".format(prog=parser.prog, version=__version__),
+        version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_files", nargs="*")
     args = parser.parse_args()
@@ -191,12 +187,12 @@ def main():
             hdlr = logging.FileHandler(args.logfile)
             hdlr.setFormatter(formatter)
             logger.addHandler(hdlr)
-        except IOError:
+        except OSError:
             logger.exception("Could not open log file: %s" % (args.logfile))
 
     src_filename = args.input_files[0]
     json_file = os.path.join(os.path.dirname(os.path.abspath(src_filename)), "node_list.json")
-    with open(json_file, "r") as fd:
+    with open(json_file) as fd:
         res = json.load(fd)
     rows = make_dict(res)
 

--- a/pyx12/examples/node_iterator.py
+++ b/pyx12/examples/node_iterator.py
@@ -56,7 +56,7 @@ def x12n_iterator(param, src_file, map_path=None):
             print("--------------------------------------------")
             # reset to control map for ISA and GS loops
             print("------- counters before --------")
-            print((walker.counter._dict))
+            print(walker.counter._dict)
         if seg.get_seg_id() == "ISA":
             node = control_map.getnodebypath("/ISA_LOOP/ISA")
             walker.forceWalkCounterToLoopStart("/ISA_LOOP", "/ISA_LOOP/ISA")
@@ -76,7 +76,7 @@ def x12n_iterator(param, src_file, map_path=None):
 
         if False:
             print("------- counters after --------")
-            print((walker.counter._dict))
+            print(walker.counter._dict)
         if node is None:
             node = orig_node
         else:
@@ -91,9 +91,7 @@ def x12n_iterator(param, src_file, map_path=None):
                 if map_file != map_file_new:
                     map_file = map_file_new
                     if map_file is None:
-                        err_str = "Map not found.  icvn={}, fic={}, vriic={}".format(
-                            icvn, fic, vriic
-                        )
+                        err_str = f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}"
                         raise pyx12.errors.EngineError(err_str)
                     cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                     src.check_837_lx = True if cur_map.id == "837" else False
@@ -110,9 +108,7 @@ def x12n_iterator(param, src_file, map_path=None):
                     if map_file != map_file_new:
                         map_file = map_file_new
                         if map_file is None:
-                            err_str = "Map not found.  icvn={}, fic={}, vriic={}, tspc={}".format(
-                                icvn, fic, vriic, tspc
-                            )
+                            err_str = f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}, tspc={tspc}"
                             raise pyx12.errors.EngineError(err_str)
                         cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
                         src.check_837_lx = True if cur_map.id == "837" else False
@@ -192,16 +188,12 @@ def clean_name(name):
 
 def check_map_path_arg(map_path):
     if not os.path.isdir(map_path):
-        raise argparse.ArgumentError(
-            None, "The MAP_PATH '{}' is not a valid directory".format(map_path)
-        )
+        raise argparse.ArgumentError(None, f"The MAP_PATH '{map_path}' is not a valid directory")
     index_file = "maps.xml"
     if not os.path.isfile(os.path.join(map_path, index_file)):
         raise argparse.ArgumentError(
             None,
-            "The MAP_PATH '{}' does not contain the map index file '{}'".format(
-                map_path, index_file
-            ),
+            f"The MAP_PATH '{map_path}' does not contain the map index file '{index_file}'",
         )
     return map_path
 
@@ -223,7 +215,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="{prog} {version}".format(prog=parser.prog, version=__version__),
+        version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_files", nargs="*")
     args = parser.parse_args()
@@ -252,7 +244,7 @@ def main():
             hdlr = logging.FileHandler(args.logfile)
             hdlr.setFormatter(formatter)
             logger.addHandler(hdlr)
-        except IOError:
+        except OSError:
             logger.exception("Could not open log file: %s" % (args.logfile))
 
     for src_filename in args.input_files:
@@ -267,7 +259,7 @@ def main():
             with open(json_file, "w") as fd:
                 json.dump(res, fd, indent=4)
 
-        except IOError:
+        except OSError:
             logger.exception("Could not open files")
             return False
         except KeyboardInterrupt:

--- a/pyx12/examples/st_context_iterator.py
+++ b/pyx12/examples/st_context_iterator.py
@@ -23,8 +23,7 @@ def st_generator():
             # yield (k, g)
             print("-----------------------------------------------------------")
             print(k)
-            for d in g:
-                yield d
+            yield from g
             print("-----------------------------------------------------------")
         # for d in iterate_2000(fd_in):
         #    yield d
@@ -67,7 +66,7 @@ def save_many(src_filename, targetformat=None):
         if targetformat is not None:
             newname = targetformat.format(isa_id=isa_id, gs_id=gs_id, st_id=st_id)
         else:
-            newname = "newfile_{isa_id}.txt".format(isa_id=isa_id)
+            newname = f"newfile_{isa_id}.txt"
         with open(newname, "w", encoding="ascii") as fd_out:
             fd_temp.seek(0)
             fd_out.write(fd_temp.read())
@@ -75,12 +74,12 @@ def save_many(src_filename, targetformat=None):
 
 
 def update_isa_id(seg_data, isa_id):
-    seg_data.set("ISA13", "{0:0>9}".format(int(isa_id)))
+    seg_data.set("ISA13", f"{int(isa_id):0>9}")
     return seg_data
 
 
 def update_gs_id(seg_data, gs_id):
-    seg_data.set("GS06", "{0}".format(int(gs_id)))
+    seg_data.set("GS06", f"{int(gs_id)}")
     return seg_data
 
 
@@ -151,14 +150,14 @@ def _get_unique_isa_id():
     """
     Generate a random, 4 to 9 character ISA ID
     """
-    return "{0:0>9}".format(random.randint(1000, 999999999))
+    return f"{random.randint(1000, 999999999):0>9}"
 
 
 def _get_unique_gs_id():
     """
     Generate a random, 3 to 9 character GS ID
     """
-    return "{0}".format(random.randint(100, 999999999))
+    return f"{random.randint(100, 999999999)}"
 
 
 def _get_unique_st_id():
@@ -166,7 +165,7 @@ def _get_unique_st_id():
     Generate a random, 4 to 9 character ST ID
     """
     # return '%04i' % (random.randint(10, 999999999))
-    return "{0:0>4}".format(random.randint(100, 999999999))
+    return f"{random.randint(100, 999999999):0>4}"
 
 
 def main():

--- a/pyx12/examples/st_iterator.py
+++ b/pyx12/examples/st_iterator.py
@@ -31,7 +31,7 @@ def save_many(src_filename, targetformat=None):
         if targetformat is not None:
             newname = targetformat.format(isa_id=isa_id, gs_id=gs_id, st_id=st_id)
         else:
-            newname = "newfile_{isa_id}.txt".format(isa_id=isa_id)
+            newname = f"newfile_{isa_id}.txt"
         with open(newname, "w", encoding="ascii") as fd_out:
             fd_temp.seek(0)
             fd_out.write(fd_temp.read())
@@ -39,12 +39,12 @@ def save_many(src_filename, targetformat=None):
 
 
 def update_isa_id(seg_data, isa_id):
-    seg_data.set("ISA13", "{0:0>9}".format(int(isa_id)))
+    seg_data.set("ISA13", f"{int(isa_id):0>9}")
     return seg_data
 
 
 def update_gs_id(seg_data, gs_id):
-    seg_data.set("GS06", "{0}".format(int(gs_id)))
+    seg_data.set("GS06", f"{int(gs_id)}")
     return seg_data
 
 

--- a/pyx12/map/dump.py
+++ b/pyx12/map/dump.py
@@ -10,7 +10,7 @@ from pyx12.params import params
 
 
 def donode(node):
-    print((node.get_path()))
+    print(node.get_path())
     for child in node.children:
         if child.is_loop() or child.is_segment():
             donode(child)

--- a/pyx12/map_if/_loader.py
+++ b/pyx12/map_if/_loader.py
@@ -37,20 +37,18 @@ def load_map_file(map_file: str, param: Any, map_path: str | None = None) -> map
     logger = logging.getLogger("pyx12")
     # Reject any path component in map_file to prevent traversal out of map_path
     if map_file != os.path.basename(map_file) or os.path.isabs(map_file):
-        raise EngineError("Invalid map file name: {}".format(map_file))
+        raise EngineError(f"Invalid map file name: {map_file}")
     map_fd: IO[Any]
     if map_path is not None:
-        logger.debug("Looking for map file '{}' in map_path '{}'".format(map_file, map_path))
+        logger.debug(f"Looking for map file '{map_file}' in map_path '{map_path}'")
         if not os.path.isdir(map_path):
             raise OSError(2, "Map path does not exist", map_path)
         full_path = os.path.join(map_path, map_file)
         if not os.path.isfile(full_path):
-            raise OSError(
-                2, "Pyx12 map file '{}' does not exist in map path".format(map_file), map_path
-            )
+            raise OSError(2, f"Pyx12 map file '{map_file}' does not exist in map path", map_path)
         map_fd = open(full_path, encoding="utf-8")
     else:
-        logger.debug("Looking for map file '{}' in package resources".format(map_file))
+        logger.debug(f"Looking for map file '{map_file}' in package resources")
         map_fd = _res_files("pyx12").joinpath("map", map_file).open("rb")
     with map_fd:
         logger.debug("Create map from %s" % (map_file))

--- a/pyx12/map_if/_loop.py
+++ b/pyx12/map_if/_loop.py
@@ -137,8 +137,7 @@ class loop_if(x12_node):
 
     def childIterator(self) -> Iterator[Any]:
         for ord1 in sorted(self.pos_map):
-            for child in self.pos_map[ord1]:
-                yield child
+            yield from self.pos_map[ord1]
 
     def getnodebypath(self, spath: str) -> Any:
         """
@@ -309,5 +308,4 @@ class loop_if(x12_node):
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
                 if child.is_loop() or child.is_segment():
-                    for c in child.loop_segment_iterator():
-                        yield c
+                    yield from child.loop_segment_iterator()

--- a/pyx12/map_if/_root.py
+++ b/pyx12/map_if/_root.py
@@ -210,5 +210,4 @@ class map_if(x12_node):
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
                 if child.is_loop() or child.is_segment():
-                    for c in child.loop_segment_iterator():
-                        yield c
+                    yield from child.loop_segment_iterator()

--- a/pyx12/map_walker.py
+++ b/pyx12/map_walker.py
@@ -18,7 +18,8 @@ If seg indicates a segment has been entered, returns the segment node.
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping, NamedTuple
+from collections.abc import Mapping
+from typing import Any, NamedTuple
 
 import pyx12.path
 import pyx12.segment

--- a/pyx12/nodeCounter.py
+++ b/pyx12/nodeCounter.py
@@ -15,7 +15,7 @@ Loop and segment counter
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Mapping
+from collections.abc import Mapping
 
 import pyx12.path
 

--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -38,17 +38,13 @@ def check_map_path_arg(map_path):
     if not isdir(map_path):
         raise argparse.ArgumentError(
             None,
-            "The MAP_PATH '{}' is not a valid directory.  Current directory is {}".format(
-                map_path, os.getcwd()
-            ),
+            f"The MAP_PATH '{map_path}' is not a valid directory.  Current directory is {os.getcwd()}",
         )
     index_file = "maps.xml"
     if not isfile(os.path.join(map_path, index_file)):
         raise argparse.ArgumentError(
             None,
-            "The MAP_PATH '{}' does not contain the map index file '{}'".format(
-                map_path, index_file
-            ),
+            f"The MAP_PATH '{map_path}' does not contain the map index file '{index_file}'",
         )
     return map_path
 
@@ -83,7 +79,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="{prog} {version}".format(prog=parser.prog, version=__version__),
+        version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_files", nargs="*")
     args = parser.parse_args()
@@ -134,7 +130,7 @@ def main():
                         target_html = src_filename + ".html"
                     fd_html = open(target_html, "w", encoding="utf-8")
 
-                logger.debug("Before x12n_document for {}".format(src_filename))
+                logger.debug(f"Before x12n_document for {src_filename}")
                 if pyx12.x12n_document.x12n_document(
                     param=param,
                     src_file=src_filename,
@@ -146,7 +142,7 @@ def main():
                     sys.stderr.write("%s: OK\n" % (src_filename))
                 else:
                     sys.stderr.write("%s: Failure\n" % (src_filename))
-                logger.debug("after x12n_document for {}".format(src_filename))
+                logger.debug(f"after x12n_document for {src_filename}")
                 if flag_997 and fd_997.tell() != 0:
                     fd_997.seek(0)
                     if os.path.splitext(src_filename)[1] == ".txt":

--- a/pyx12/scripts/x12xml.py
+++ b/pyx12/scripts/x12xml.py
@@ -36,16 +36,12 @@ __date__ = pyx12.__date__
 
 def check_map_path_arg(map_path):
     if not isdir(map_path):
-        raise argparse.ArgumentError(
-            None, "The MAP_PATH '{}' is not a valid directory".format(map_path)
-        )
+        raise argparse.ArgumentError(None, f"The MAP_PATH '{map_path}' is not a valid directory")
     index_file = "maps.xml"
     if not isfile(os.path.join(map_path, index_file)):
         raise argparse.ArgumentError(
             None,
-            "The MAP_PATH '{}' does not contain the map index file '{}'".format(
-                map_path, index_file
-            ),
+            f"The MAP_PATH '{map_path}' does not contain the map index file '{index_file}'",
         )
     return map_path
 
@@ -79,7 +75,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="{prog} {version}".format(prog=parser.prog, version=__version__),
+        version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_file")
     args = parser.parse_args()
@@ -110,7 +106,7 @@ def main():
             hdlr = logging.FileHandler(args.logfile)
             hdlr.setFormatter(formatter)
             logger.addHandler(hdlr)
-        except IOError:
+        except OSError:
             logger.exception("Could not open log file: %s" % (args.logfile))
 
     if args.input_file:

--- a/pyx12/scripts/xmlx12.py
+++ b/pyx12/scripts/xmlx12.py
@@ -40,7 +40,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="{prog} {version}".format(prog=parser.prog, version=__version__),
+        version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_file")
     args = parser.parse_args()
@@ -64,7 +64,7 @@ def main():
             hdlr = logging.FileHandler(args.logfile)
             hdlr.setFormatter(formatter)
             logger.addHandler(hdlr)
-        except IOError:
+        except OSError:
             logger.exception("Could not open log file: %s" % (args.logfile))
 
     if args.input_file:

--- a/pyx12/segment.py
+++ b/pyx12/segment.py
@@ -249,7 +249,7 @@ class Composite:
     def values_iterator(self) -> Iterator[tuple[str, str]]:
         for j in range(len(self.elements)):
             if not self.elements[j].is_empty():
-                subele_ord = "{comp}".format(comp=j + 1)
+                subele_ord = f"{j + 1}"
                 yield (subele_ord, self.elements[j].get_value())
 
 
@@ -382,7 +382,7 @@ class Segment:
         """
         ele_idx, comp_idx = self._parse_refdes(ref_des)
         if ele_idx is None:
-            raise IndexError("{} is not a valid element index".format(ref_des))
+            raise IndexError(f"{ref_des} is not a valid element index")
         if ele_idx >= self.__len__():
             return None
         if comp_idx is None:
@@ -424,7 +424,7 @@ class Segment:
         """
         ele_idx, comp_idx = self._parse_refdes(ref_des)
         if ele_idx is None:
-            raise IndexError("{} is not a valid element index".format(ref_des))
+            raise IndexError(f"{ref_des} is not a valid element index")
         while len(self.elements) <= ele_idx:
             # insert blank values before our value if needed
             self.elements.append(Composite("", self.subele_term))
@@ -448,7 +448,7 @@ class Segment:
         """
         ele_idx = self._parse_refdes(ref_des)[0]
         if ele_idx is None:
-            raise IndexError("{} is not a valid element index".format(ref_des))
+            raise IndexError(f"{ref_des} is not a valid element index")
         return self.elements[ele_idx].is_element()
 
     def is_composite(self, ref_des: str) -> bool:
@@ -458,7 +458,7 @@ class Segment:
         """
         ele_idx = self._parse_refdes(ref_des)[0]
         if ele_idx is None:
-            raise IndexError("{} is not a valid element index".format(ref_des))
+            raise IndexError(f"{ref_des} is not a valid element index")
         return self.elements[ele_idx].is_composite()
 
     def ele_len(self, ref_des: str) -> int:
@@ -470,7 +470,7 @@ class Segment:
         """
         ele_idx = self._parse_refdes(ref_des)[0]
         if ele_idx is None:
-            raise IndexError("{} is not a valid element index".format(ref_des))
+            raise IndexError(f"{ref_des} is not a valid element index")
         return len(self.elements[ele_idx])
 
     def set_seg_term(self, seg_term: str) -> None:
@@ -579,13 +579,11 @@ class Segment:
         for i in range(len(self.elements)):
             if self.elements[i].is_composite():
                 for comp_ord, val in self.elements[i].values_iterator():
-                    ele_ord = "{idx:0>2}".format(idx=i + 1)
-                    refdes = "{segid}{ele_ord}-{comp_ord}".format(
-                        segid=self.seg_id, ele_ord=ele_ord, comp_ord=comp_ord
-                    )
+                    ele_ord = f"{i + 1:0>2}"
+                    refdes = f"{self.seg_id}{ele_ord}-{comp_ord}"
                     yield (refdes, ele_ord, comp_ord, val)
             else:
                 if not self.elements[i].is_empty():
-                    ele_ord = "{idx:0>2}".format(idx=i + 1)
-                    refdes = "{segid}{ele_ord}".format(segid=self.seg_id, ele_ord=ele_ord)
+                    ele_ord = f"{i + 1:0>2}"
+                    refdes = f"{self.seg_id}{ele_ord}"
                     yield (refdes, ele_ord, None, self.elements[i].get_value())

--- a/pyx12/syntax.py
+++ b/pyx12/syntax.py
@@ -32,7 +32,7 @@ def is_syntax_valid(
     """
     # handle intra-segment dependancies
     if len(syn) < 3:
-        err_str = "Syntax string must have at least two comparators {}".format(syntax_str(syn))
+        err_str = f"Syntax string must have at least two comparators {syntax_str(syn)}"
         return (False, err_str)
 
     syn_code = syn[0]
@@ -41,31 +41,29 @@ def is_syntax_valid(
     if syn_code == "P":
         count = 0
         for s in syn_idx:
-            _val = seg_data.get_value("{:02d}".format(s))
+            _val = seg_data.get_value(f"{s:02d}")
             if len(seg_data) >= s and _val != "":
                 count += 1
         if count != 0 and count != len(syn_idx):
-            err_str = "Syntax Error ({}): If any of {} is present, then all are required".format(
-                syntax_str(syn), syntax_ele_id_str(seg_data.get_seg_id(), syn_idx)
-            )
+            err_str = f"Syntax Error ({syntax_str(syn)}): If any of {syntax_ele_id_str(seg_data.get_seg_id(), syn_idx)} is present, then all are required"
             return (False, err_str)
         else:
             return (True, None)
     elif syn_code == "R":
         count = 0
         for s in syn_idx:
-            _val = seg_data.get_value("{:02d}".format(s))
+            _val = seg_data.get_value(f"{s:02d}")
             if len(seg_data) >= s and _val != "":
                 count += 1
         if count == 0:
-            err_str = "Syntax Error ({}): At least one element is required".format(syntax_str(syn))
+            err_str = f"Syntax Error ({syntax_str(syn)}): At least one element is required"
             return (False, err_str)
         else:
             return (True, None)
     elif syn_code == "E":
         count = 0
         for s in syn_idx:
-            _val = seg_data.get_value("{:02d}".format(s))
+            _val = seg_data.get_value(f"{s:02d}")
             if len(seg_data) >= s and _val != "":
                 count += 1
         if count > 1:
@@ -81,7 +79,7 @@ def is_syntax_valid(
         if len(seg_data) >= syn_idx[0] and seg_data.get_value("%02i" % (syn_idx[0])) != "":
             count = 0
             for s in syn_idx[1:]:
-                _val = seg_data.get_value("{:02d}".format(s))
+                _val = seg_data.get_value(f"{s:02d}")
                 if len(seg_data) >= s and _val != "":
                     count += 1
             if count != len(syn_idx) - 1:
@@ -105,7 +103,7 @@ def is_syntax_valid(
         if len(seg_data) > syn_idx[0] - 1 and seg_data.get_value("%02i" % (syn_idx[0])) != "":
             count = 0
             for s in syn_idx[1:]:
-                _val = seg_data.get_value("{:02d}".format(s))
+                _val = seg_data.get_value(f"{s:02d}")
                 if len(seg_data) >= s and _val != "":
                     count += 1
             if count == 0:
@@ -131,7 +129,7 @@ def syntax_str(syntax: list[Any]) -> str:
     """
     output: str = str(syntax[0])
     for i in syntax[1:]:
-        output += "{:02d}".format(int(i))
+        output += f"{int(i):02d}"
     return output
 
 
@@ -140,10 +138,10 @@ def syntax_ele_id_str(seg_id: str | None, ele_pos_list: list[int]) -> str:
     :rtype: string
     """
     output = ""
-    output += "{seg_id}{ele_pos:02d}".format(seg_id=seg_id, ele_pos=ele_pos_list[0])
+    output += f"{seg_id}{ele_pos_list[0]:02d}"
     for i in range(len(ele_pos_list) - 1):
         if i == len(ele_pos_list) - 2:
-            output += " or {seg_id}{ele_pos:02d}".format(seg_id=seg_id, ele_pos=ele_pos_list[i + 1])
+            output += f" or {seg_id}{ele_pos_list[i + 1]:02d}"
         else:
-            output += ", {seg_id}{ele_pos:02d}".format(seg_id=seg_id, ele_pos=ele_pos_list[i + 1])
+            output += f", {seg_id}{ele_pos_list[i + 1]:02d}"
     return output

--- a/pyx12/test/test_xmlwriter.py
+++ b/pyx12/test/test_xmlwriter.py
@@ -38,7 +38,7 @@ class TestWriter(unittest.TestCase):
             while len(writer) > 0:
                 writer.pop()
 
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             self.assertEqual(fd.read(), self.res)
 
         try:

--- a/pyx12/validation.py
+++ b/pyx12/validation.py
@@ -268,8 +268,8 @@ def contains_control_character(
     }
     for k, v in control_base.items():
         if k in str_val:
-            return (True, "<{}>".format(v))
+            return (True, f"<{v}>")
     for k, v in extended_base.items():
         if k in str_val:
-            return (True, "<{}>".format(v))
+            return (True, f"<{v}>")
     return (False, None)

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -258,8 +258,7 @@ class X12DataNode:
                     else:
                         child_path = path.X12Path(x12path.format())
                         child_path.loop_list = cur_loop_list
-                        for n in child._select(child_path):
-                            yield n
+                        yield from child._select(child_path)
 
     def __copy__(self) -> X12DataNode:
         """
@@ -375,8 +374,7 @@ class X12LoopDataNode(X12DataNode):
         Iterate over this node and children
         """
         for child in [x for x in self.children if x.type is not None]:
-            for a in child.iterate_segments():
-                yield a
+            yield from child.iterate_segments()
 
     def iterate_loop_segments(self) -> Iterator[dict[str, Any]]:
         """
@@ -386,8 +384,7 @@ class X12LoopDataNode(X12DataNode):
             yield {"node": loop, "type": "loop_end", "id": loop.id}
         yield {"type": "loop_start", "id": self.id, "node": self.x12_map_node}
         for child in [x for x in self.children if x.type is not None]:
-            for a in child.iterate_loop_segments():
-                yield a
+            yield from child.iterate_loop_segments()
         yield {"type": "loop_end", "id": self.id, "node": self.x12_map_node}
 
     def add_segment(self, seg_data: pyx12.segment.Segment | str) -> X12SegmentDataNode:
@@ -1157,7 +1154,7 @@ class X12ContextReader:
             new_node = X12SegmentDataNode(self.x12_map_node, seg_data)
         except Exception:
             mypath = self.x12_map_node.get_path()
-            err_str = "X12SegmentDataNode failed: x12_path={}, seg_date={}".format(mypath, seg_data)
+            err_str = f"X12SegmentDataNode failed: x12_path={mypath}, seg_date={seg_data}"
             raise errors.EngineError(err_str) from None
         try:
             new_node.parent = cur_loop_node

--- a/pyx12/x12file.py
+++ b/pyx12/x12file.py
@@ -98,20 +98,20 @@ class X12Base:
         :type seg_data: L{segment<segment.Segment>}
         """
         if seg_data.is_empty():
-            err_str = 'Segment "{}" is empty'.format(seg_data)
+            err_str = f'Segment "{seg_data}" is empty'
             self._seg_error("8", err_str, None, src_line=self.cur_line + 1)
         if not seg_data.is_seg_id_valid():
-            err_str = 'Segment identifier "{}" is invalid'.format(seg_data.get_seg_id())
+            err_str = f'Segment identifier "{seg_data.get_seg_id()}" is invalid'
             self._seg_error("1", err_str, None, src_line=self.cur_line + 1)
         seg_id = seg_data.get_seg_id()
         if seg_id == "ISA":
             if len(seg_data) != 16:
-                err_str = "The ISA segment must have 16 elements ({})".format(seg_data)
+                err_str = f"The ISA segment must have 16 elements ({seg_data})"
                 raise pyx12.errors.X12Error(err_str)
             interchange_control_number = seg_data.get_value("ISA13")
             if interchange_control_number in self.isa_ids:
                 err_str = "ISA Interchange Control Number "
-                err_str += "{} not unique within file".format(interchange_control_number)
+                err_str += f"{interchange_control_number} not unique within file"
                 self._isa_error("025", err_str)
             self.loops.append(("ISA", interchange_control_number))
             self.isa_ids.append(interchange_control_number)
@@ -122,7 +122,7 @@ class X12Base:
             group_control_number = seg_data.get_value("GS06")
             if group_control_number in self.gs_ids:
                 err_str = "GS Interchange Control Number "
-                err_str += "{} not unique within file".format(group_control_number)
+                err_str += f"{group_control_number} not unique within file"
                 self._gs_error("6", err_str)
             self.gs_count += 1
             self.gs_ids.append(group_control_number)
@@ -135,7 +135,7 @@ class X12Base:
             transaction_control_number = seg_data.get_value("ST02")
             if transaction_control_number in self.st_ids:
                 err_str = "ST Interchange Control Number "
-                err_str += "{} not unique within file".format(transaction_control_number)
+                err_str += f"{transaction_control_number} not unique within file"
                 self._st_error("23", err_str)
             self.st_count += 1
             self.st_ids.append(transaction_control_number)
@@ -155,14 +155,12 @@ class X12Base:
                 # raise pyx12.errors.X12Error, \
                 #   'My HL count %i does not match your HL count %s' \
                 #    % (self.hl_count, seg[1])
-                err_str = "My HL count {:d} does not match your HL count {}".format(
-                    self.hl_count, hl_count
-                )
+                err_str = f"My HL count {self.hl_count:d} does not match your HL count {hl_count}"
                 self._seg_error("HL1", err_str)
             if seg_data.get_value("HL02") != "":
                 hl_parent = self._int(seg_data.get_value("HL02"))
                 if hl_parent not in self.hl_stack:
-                    err_str = "HL parent ({}) is not a valid parent".format(hl_parent)
+                    err_str = f"HL parent ({hl_parent}) is not a valid parent"
                     self._seg_error("HL2", err_str)
                 while self.hl_stack and hl_parent != self.hl_stack[-1]:
                     del self.hl_stack[-1]
@@ -176,7 +174,7 @@ class X12Base:
             self.lx_count = 0
         elif self.check_837_lx and seg_id == "LX":
             self.lx_count += 1
-            if seg_data.get_value("LX01") != "{:d}".format(self.lx_count):
+            if seg_data.get_value("LX01") != f"{self.lx_count:d}":
                 err_str = (
                     "Your 2400/LX01 Service Line Number {} does not match my count of {:d}".format(
                         seg_data.get_value("LX01"), self.lx_count
@@ -349,7 +347,7 @@ class X12Reader(X12Base):
             if src_file_obj == "-":
                 self.fd_in = sys.stdin
             else:
-                self.fd_in = open(src_file_obj, "r", encoding="ascii")  # type: ignore[arg-type, assignment]
+                self.fd_in = open(src_file_obj, encoding="ascii")  # type: ignore[arg-type]
                 self.need_to_close = True
         X12Base.__init__(self)
         try:
@@ -396,7 +394,7 @@ class X12Reader(X12Base):
         if seg_id == "IEA":
             if self.loops[-1][0] != "ISA":
                 # Unterminated GS loop
-                err_str = "Unterminated Loop {}".format(self.loops[-1][0])
+                err_str = f"Unterminated Loop {self.loops[-1][0]}"
                 self._isa_error("024", err_str)
                 del self.loops[-1]
             if self.loops[-1][1] != seg_data.get_value("IEA02"):
@@ -410,7 +408,7 @@ class X12Reader(X12Base):
             del self.loops[-1]
         elif seg_id == "GE":
             if self.loops[-1][0] != "GS":
-                err_str = "Unterminated segment {}".format(self.loops[-1][1])
+                err_str = f"Unterminated segment {self.loops[-1][1]}"
                 self._gs_error("3", err_str)
                 del self.loops[-1]
             if self.loops[-1][1] != seg_data.get_value("GE02"):
@@ -427,9 +425,7 @@ class X12Reader(X12Base):
         elif seg_id == "SE":
             se_trn_control_num = seg_data.get_value("SE02")
             if self.loops[-1][0] != "ST" or self.loops[-1][1] != se_trn_control_num:
-                err_str = "SE id={} does not match ST id={}".format(
-                    se_trn_control_num, self.loops[-1][1]
-                )
+                err_str = f"SE id={se_trn_control_num} does not match ST id={self.loops[-1][1]}"
                 self._st_error("3", err_str)
             if self._int(seg_data.get_value("SE01")) != self.seg_count + 1:
                 err_str = "SE count of {} for SE02={} is wrong. I count {}".format(
@@ -465,15 +461,15 @@ class X12Reader(X12Base):
             for seg, id1 in self.loops:
                 if seg == "ST":
                     err_str = 'Mandatory segment "Transaction Set Trailer" '
-                    err_str += "(SE={}) missing".format(id1)
+                    err_str += f"(SE={id1}) missing"
                     self._st_error("2", err_str)
                 elif seg == "GS":
                     err_str = 'Mandatory segment "Functional Group Trailer" '
-                    err_str += "(GE={}) missing".format(id1)
+                    err_str += f"(GE={id1}) missing"
                     self._gs_error("3", err_str)
                 elif seg == "ISA":
                     err_str = 'Mandatory segment "Interchange Control Trailer" '
-                    err_str += "(IEA={}) missing".format(id1)
+                    err_str += f"(IEA={id1}) missing"
                     self._isa_error("023", err_str)
                 # elif self.loops[-1][0] == 'LS':
                 #    err_str = 'LS id=%s was not closed with a LE' % \
@@ -573,7 +569,7 @@ class X12Writer(X12Base):
             self._popToLoop("ST")
         elif self.check_837_lx and seg_id == "LX":
             # Write our own LX counter
-            seg_data.set("01", "{:d}".format(self.lx_count))
+            seg_data.set("01", f"{self.lx_count:d}")
             self._write_segment(seg_data)
         elif seg_id == "ISA":
             # Replace terminators
@@ -682,9 +678,7 @@ class X12Writer(X12Base):
         :type id: string
         """
         ele_term = self.ele_term
-        seg_str = "{seg_id}{ele_term}{count:d}{ele_term}{id}".format(
-            seg_id=seg_id, ele_term=ele_term, count=count, id=id
-        )
+        seg_str = f"{seg_id}{ele_term}{count:d}{ele_term}{id}"
         return pyx12.segment.Segment(
             seg_str,
             self.seg_term,  # type: ignore[arg-type]

--- a/pyx12/x12metadata.py
+++ b/pyx12/x12metadata.py
@@ -80,7 +80,7 @@ def get_x12file_metadata(
             map_file_new = map_index_if.get_filename(icvn, vriic, fic)
             if map_file != map_file_new:
                 if map_file_new is None:
-                    err_str = "Map not found.  icvn={}, fic={}, vriic={}".format(icvn, fic, vriic)
+                    err_str = f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}"
                     raise pyx12.errors.EngineError(err_str)
                 map_file = map_file_new
                 cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
@@ -96,8 +96,8 @@ def get_x12file_metadata(
                 logger.debug("New map file: %s" % (map_file_new))
                 if map_file != map_file_new:
                     if map_file_new is None:
-                        err_str = "Map not found.  icvn={}, fic={}, vriic={}, tspc={}".format(
-                            icvn, fic, vriic, tspc
+                        err_str = (
+                            f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}, tspc={tspc}"
                         )
                         raise pyx12.errors.EngineError(err_str)
                     map_file = map_file_new

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -119,7 +119,7 @@ def x12n_document(
             print("--------------------------------------------")
             # reset to control map for ISA and GS loops
             print("------- counters before --------")
-            print((walker.counter._dict))
+            print(walker.counter._dict)
         if seg.get_seg_id() == "ISA":
             node = control_map.getnodebypath("/ISA_LOOP/ISA")
             walker.forceWalkCounterToLoopStart("/ISA_LOOP", "/ISA_LOOP/ISA")
@@ -139,7 +139,7 @@ def x12n_document(
 
         if False:
             print("------- counters after --------")
-            print((walker.counter._dict))
+            print(walker.counter._dict)
         if node is None:
             node = orig_node
         else:
@@ -157,9 +157,7 @@ def x12n_document(
                 map_file_new = map_index_if.get_filename(icvn, vriic, fic)
                 if map_file != map_file_new:
                     if map_file_new is None:
-                        err_str = "Map not found.  icvn={}, fic={}, vriic={}".format(
-                            icvn, fic, vriic
-                        )
+                        err_str = f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}"
                         raise pyx12.errors.EngineError(err_str)
                     map_file = map_file_new
                     cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)
@@ -182,9 +180,7 @@ def x12n_document(
                     logger.debug("New map file: %s" % (map_file_new))
                     if map_file != map_file_new:
                         if map_file_new is None:
-                            err_str = "Map not found.  icvn={}, fic={}, vriic={}, tspc={}".format(
-                                icvn, fic, vriic, tspc
-                            )
+                            err_str = f"Map not found.  icvn={icvn}, fic={fic}, vriic={vriic}, tspc={tspc}"
                             raise pyx12.errors.EngineError(err_str)
                         map_file = map_file_new
                         cur_map = pyx12.map_if.load_map_file(map_file, param, map_path)

--- a/pyx12/x12xml.py
+++ b/pyx12/x12xml.py
@@ -84,14 +84,14 @@ class x12xml:
         self.writer.push(xname, attrib)
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
-            _ele = seg_data.get("{idx:02d}".format(idx=i + 1))
+            _ele = seg_data.get(f"{i + 1:02d}")
             assert _ele is not None  # within range(len(seg_data))
             if child_node.usage == "N" or _ele.is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node_id)
                 self.writer.push(xname, attrib)
-                comp_data = seg_data.get("{idx:02d}".format(idx=i + 1))
+                comp_data = seg_data.get(f"{i + 1:02d}")
                 assert isinstance(comp_data, pyx12.segment.Composite)
                 for j in range(len(comp_data)):
                     subele_node = child_node.get_child_node_by_idx(j)
@@ -99,7 +99,7 @@ class x12xml:
                     self.writer.elem(xname, comp_data[j].get_value(), attrib)
                 self.writer.pop()  # end composite
             elif child_node.is_element():
-                ele_val = seg_data.get_value("{idx:02d}".format(idx=i + 1))
+                ele_val = seg_data.get_value(f"{i + 1:02d}")
                 if ele_val == "" or ele_val is None:
                     pass
                     # self.writer.empty(u"ele", attrs={u'id': child_node.id})
@@ -137,14 +137,14 @@ class x12xml:
         self.writer.push(xname, attrib)
         for i in range(len(seg_data)):
             child_node = seg_node.get_child_node_by_idx(i)
-            _ele = seg_data.get("{idx:02d}".format(idx=i + 1))
+            _ele = seg_data.get(f"{i + 1:02d}")
             assert _ele is not None  # within range(len(seg_data))
             if child_node.usage == "N" or _ele.is_empty():
                 pass  # Do not try to ouput for invalid or empty elements
             elif child_node.is_composite():
                 (xname, attrib) = self._get_comp_info(seg_node.id)
                 self.writer.push(xname, attrib)
-                comp_data = seg_data.get("{idx:02d}".format(idx=i + 1))
+                comp_data = seg_data.get(f"{i + 1:02d}")
                 assert isinstance(comp_data, pyx12.segment.Composite)
                 for j in range(len(comp_data)):
                     subele_node = child_node.get_child_node_by_idx(j)
@@ -152,7 +152,7 @@ class x12xml:
                     self.writer.elem(xname, comp_data[j].get_value(), attrib)
                 self.writer.pop()  # end composite
             elif child_node.is_element():
-                ele_val = seg_data.get_value("{idx:02d}".format(idx=i + 1))
+                ele_val = seg_data.get_value(f"{i + 1:02d}")
                 if ele_val == "" or ele_val is None:
                     pass
                     # self.writer.empty(u"ele", attrs={u'id': child_node.id})

--- a/pyx12/xmlwriter.py
+++ b/pyx12/xmlwriter.py
@@ -71,16 +71,16 @@ class XMLWriter:
         self.out = out
         self.stack = []
         self.indent = indent
-        self._write('<?xml version="1.0" encoding="{}"?>\n'.format(encoding))
+        self._write(f'<?xml version="1.0" encoding="{encoding}"?>\n')
 
     def doctype(self, root: str, pubid: str | None, sysid: str) -> None:
         """
         Create a document type declaration (no internal subset)
         """
         if pubid is None:
-            self._write("<!DOCTYPE {} SYSTEM '{}'>\n".format(root, sysid))
+            self._write(f"<!DOCTYPE {root} SYSTEM '{sysid}'>\n")
         else:
-            self._write("<!DOCTYPE {} PUBLIC '{}' '{}'>\n".format(root, pubid, sysid))
+            self._write(f"<!DOCTYPE {root} PUBLIC '{pubid}' '{sysid}'>\n")
 
     def push(self, elem: str, attrs: dict[str, str] | None = None) -> None:
         """
@@ -91,7 +91,7 @@ class XMLWriter:
         self._indent()
         self._write("<" + elem)
         for a, v in attrs.items():
-            self._write(" {}='{}'".format(a, self._escape_attr(v)))
+            self._write(f" {a}='{self._escape_attr(v)}'")
         self._write(">\n")
         self.stack.append(elem)
 
@@ -104,8 +104,8 @@ class XMLWriter:
         self._indent()
         self._write("<" + elem)
         for a, v in attrs.items():
-            self._write(" {}='{}'".format(a, self._escape_attr(v)))
-        self._write(">{}</{}>\n".format(self._escape_cont(content), elem))
+            self._write(f" {a}='{self._escape_attr(v)}'")
+        self._write(f">{self._escape_cont(content)}</{elem}>\n")
 
     def empty(self, elem: str, attrs: dict[str, str] | None = None) -> None:
         """
@@ -116,7 +116,7 @@ class XMLWriter:
         self._indent()
         self._write("<" + elem)
         for a, v in attrs.items():
-            self._write(" {}='{}'".format(a, self._escape_attr(v)))
+            self._write(f" {a}='{self._escape_attr(v)}'")
         self._write("/>\n")
 
     def pop(self) -> None:
@@ -127,7 +127,7 @@ class XMLWriter:
             elem = self.stack[-1]
             del self.stack[-1]
             self._indent()
-            self._write("</{elem}>\n".format(elem=elem))
+            self._write(f"</{elem}>\n")
 
     def __len__(self) -> int:
         return len(self.stack)


### PR DESCRIPTION
Phase B of the ruff-rules review. Adds UP (pyupgrade) to the lint config; applies safe + unsafe autofixes across 26 files; opts out UP031 for now.

## Config

\`\`\`toml
[tool.ruff.lint]
select = [\"F\", \"I\", \"UP\", \"B904\"]
ignore = [\"UP031\"]
\`\`\`

## Autofixes applied (137 sites)

| Rule | Sites | What |
|---|---|---|
| UP032 | 96 | \`.format(...)\` -> f-string |
| UP028 | 11 | \`for x in xs: yield x\` -> \`yield from xs\` |
| UP030 | 11 | positional format-literal args |
| UP034 | 7 | extraneous parentheses |
| UP024 | 5 | deprecated \`os.error\` / \`IOError\` aliases |
| UP015 | 4 | redundant \`\"r\"\` mode in \`open()\` |
| UP035 | 2 | deprecated import paths |
| - | 1 | knock-on: unused \`# type: ignore[assignment]\` in \`x12file.py:350\` (UP015 dropped the redundant \`\"r\"\` mode, so the assignment now type-checks cleanly without the suppression) |

Net diff: **132 insertions / 174 deletions** across 27 files.

## Why UP031 is skipped

305 \`%\`-format sites remain after ruff handled the easy ones. They mostly format integers (line numbers, segment counts, error codes). Ruff considers UP031 unsafe because \`f\"{x}\"\` and \`\"%i\" % x\` aren't strictly equivalent — \`%i\` truncates floats, f-string doesn't. For pyx12 the values are always ints so the conversion would be safe, but a first scripted attempt mishandled multi-arg cases like \`\"%s(%i,%i)\" % (a, b, c)\` inside dict-subscript expressions and produced f-strings with quote conflicts (Python 3.12+ syntax inside a 3.11+ file). Defer as a manual sweep or skip indefinitely — these are stylistic, not bug-class.

## What this gives going forward

- F-string consistency across the codebase (almost — UP031 sites still on \`%\`)
- \`yield from\` for nested iterators
- No more \`IOError\` / deprecated alias drift

## Verification
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean (82 source files)
- [x] \`ruff check\` — clean
- [x] \`ruff format --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)