### PR TITLE
fix: PRV05 in 837.4010.X097 was tagged as <element> but is a composite

### DIFF
--- a/pyx12/map/837.4010.X097.A1.xml
+++ b/pyx12/map/837.4010.X097.A1.xml
@@ -707,12 +707,12 @@
                 <usage>N</usage>
                 <seq>04</seq>
               </element>
-              <element xid="PRV05">
+              <composite>
                 <data_ele>C035</data_ele>
                 <name>Provider Specialty Information</name>
                 <usage>N</usage>
                 <seq>05</seq>
-              </element>
+              </composite>
               <element xid="PRV06">
                 <data_ele>1223</data_ele>
                 <name>Provider Organization Code</name>


### PR DESCRIPTION
## Summary

The Provider Specialty Information field at PRV05 in [\`pyx12/map/837.4010.X097.A1.xml\`](pyx12/map/837.4010.X097.A1.xml#L710) was declared as \`<element xid=\"PRV05\">\` with \`<data_ele>C035</data_ele>\`. C035 is an X12 composite type ID, not a simple data element — \`dataele.xml\` (correctly) does not define it. The same field is declared as a \`<composite>\` elsewhere in the same file (line 3024 for a different PRV occurrence); this site was a tagging error.

## Why it didn't break anything

PRV05 has \`usage=\"N\"\` (not used) at this site, so the validation path that would have called \`data_elements.get_by_elem_num(\"C035\")\` and crashed with \`EngineError: Data Element \"C035\" is not defined\` never fires for not-used fields. Latent bug.

## How it was found

Surveyed every \`data_ele\` reference across the bundled XML maps against \`dataele.xml\`. Of 28 orphans (refs to undefined data elements), 19 are composite-type IDs (\`C001\`-\`C999\`) which are informational and never resolved at runtime — pyx12's \`composite_if\` doesn't call \`get_by_elem_num\` on its own \`data_ele\` attr. The remaining 9 were \`<element>\` references to undefined codes; this is the only one that's structurally wrong (the others are non-HIPAA standard elements not shipped in pyx12 — see follow-up issue).

## After this PR

8 element-orphan references remain, all in non-HIPAA \`830.4010.PS.xml\` (Planning Schedule) and \`841.4010.XXXC.xml\` (Specifications/Technical Information) maps. Tracked separately.

## Test plan
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean
- [x] Orphan-element survey: 9 → 8 (C035 gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)