### PR TITLE
feat: add check_maps.py CI gate for X12 map structural correctness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,20 @@ jobs:
       - name: Run mypy
         run: uv run mypy
 
+  check-maps:
+    name: Validate bundled X12 maps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: '3.12'
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+      - name: Run map validator
+        run: uv run python tools/check_maps.py
+
   docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/tools/check_maps.py
+++ b/tools/check_maps.py
@@ -1,0 +1,137 @@
+"""Validate the bundled X12 map XML files for structural correctness.
+
+Run as a CI gate to catch the kind of map-file bugs that previously surfaced
+only at runtime (see PR #134, issue #135).
+
+Checks:
+  1. Every `<element>` references a `data_ele` defined in dataele.xml.
+  2. No `<element>` has a C-prefix `data_ele` (those identify composites
+     and a `C` data_ele on an `<element>` tag is a mistagged composite).
+  3. Every `<valid_codes external="X"/>` references a codeset defined in
+     codes.xml.
+
+Exits 0 when clean, 1 when any check fires.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from collections.abc import Iterator
+from xml.etree.ElementTree import Element
+
+import defusedxml.ElementTree as et
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+MAP_DIR = REPO_ROOT / "pyx12" / "map"
+
+# Files that aren't transaction maps — skip them.
+NON_MAPS = {"dataele.xml", "codes.xml", "maps.xml"}
+
+
+def load_defined_data_elements() -> set[str]:
+    root = et.parse(MAP_DIR / "dataele.xml").getroot()
+    return {de.get("ele_num") for de in root if de.get("ele_num")}
+
+
+def load_defined_codesets() -> set[str]:
+    root = et.parse(MAP_DIR / "codes.xml").getroot()
+    ids: set[str] = set()
+    for cs in root.findall("codeset"):
+        id_elem = cs.find("id")
+        if id_elem is not None and id_elem.text:
+            ids.add(id_elem.text.strip())
+    return ids
+
+
+def get_data_ele(node: Element) -> str | None:
+    """Read a node's data_ele as either an attribute or a child element."""
+    attr = node.get("data_ele")
+    if attr:
+        return attr
+    child = node.find("data_ele")
+    if child is not None and child.text:
+        return child.text.strip()
+    return None
+
+
+def iter_map_files() -> Iterator[pathlib.Path]:
+    for xml_path in sorted(MAP_DIR.glob("*.xml")):
+        if xml_path.name in NON_MAPS:
+            continue
+        yield xml_path
+
+
+def check_map(
+    xml_path: pathlib.Path,
+    defined_eles: set[str],
+    defined_codesets: set[str],
+) -> list[str]:
+    findings: list[str] = []
+    try:
+        tree = et.parse(xml_path)
+    except Exception as e:  # pragma: no cover — XML errors at parse time
+        return [f"failed to parse: {e}"]
+
+    for node in tree.iter():
+        if node.tag == "element":
+            de = get_data_ele(node)
+            if de is None:
+                continue
+            xid = node.get("xid", "?")
+            if de.startswith("C"):
+                findings.append(
+                    f"<element xid={xid!r}> has data_ele={de!r}; "
+                    f"the C-prefix is reserved for composites — likely mistagged "
+                    f"(should be <composite>)"
+                )
+            elif de not in defined_eles:
+                findings.append(
+                    f"<element xid={xid!r}> references undefined data_ele={de!r} "
+                    f"(not in dataele.xml)"
+                )
+
+        elif node.tag == "valid_codes":
+            ext = node.get("external")
+            if ext and ext not in defined_codesets:
+                findings.append(
+                    f"<valid_codes external={ext!r}/> references unknown codeset (not in codes.xml)"
+                )
+
+    return findings
+
+
+def main() -> int:
+    defined_eles = load_defined_data_elements()
+    defined_codesets = load_defined_codesets()
+
+    print(
+        f"check_maps: scanning {MAP_DIR.relative_to(REPO_ROOT)} "
+        f"against {len(defined_eles)} data elements and "
+        f"{len(defined_codesets)} codesets"
+    )
+
+    failed_files: dict[str, list[str]] = {}
+    file_count = 0
+    for xml_path in iter_map_files():
+        file_count += 1
+        findings = check_map(xml_path, defined_eles, defined_codesets)
+        if findings:
+            failed_files[xml_path.name] = findings
+
+    if not failed_files:
+        print(f"OK: {file_count} map files clean.")
+        return 0
+
+    total = sum(len(v) for v in failed_files.values())
+    print(f"\nFAIL: {total} finding(s) across {len(failed_files)} of {file_count} files:\n")
+    for fname, findings in sorted(failed_files.items()):
+        print(f"--- {fname} ---")
+        for f in findings:
+            print(f"  {f}")
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Recommendation #3 from the [architectural review](C:\Users\john\.claude\plans\starry-watching-sketch.md). Smallest scope of the review's options, catches a real recurring class of bugs (PRs #134, #136 / issue #135), self-contained — does not touch the parser or any runtime hot path.

## What it checks

| # | Rule |
|---|---|
| 1 | Every \`<element data_ele=\"N\">\`: \`N\` is defined in [\`dataele.xml\`](pyx12/map/dataele.xml) |
| 2 | No \`<element>\` has a C-prefix \`data_ele\` (those identify composites; an \`<element>\` with C* is mistagged) |
| 3 | Every \`<valid_codes external=\"X\"/>\` references a codeset defined in [\`codes.xml\`](pyx12/map/codes.xml) |

Scans all 32 transaction maps in [\`pyx12/map/\`](pyx12/map/) against 345 simple data elements and 9 codesets. Exit 0 on clean, exit 1 on findings.

## Sample output

\`\`\`
$ python tools/check_maps.py
check_maps: scanning pyx12\map against 345 data elements and 9 codesets
OK: 32 map files clean.
\`\`\`

When deliberately broken (\`<data_ele>98</data_ele>\` → \`<data_ele>99999</data_ele>\` in \`comp_test.xml\`):

\`\`\`
FAIL: 1 finding(s) across 1 of 32 files:

--- comp_test.xml ---
  <element xid='?'> references undefined data_ele='99999' (not in dataele.xml)
\`\`\`

## CI integration

New \`check-maps\` job in [\`.github/workflows/main.yml\`](.github/workflows/main.yml) runs the script on every push and pull request. Map edits that introduce the bug class from #134 / #135 will now fail CI at review time instead of becoming user-reported runtime errors months later.

## Why these 3 checks (and not more)

The architectural review proposed 5 checks. Three high-value ones are in this PR:
- The data_ele orphan check (caught 8 bugs in #135)
- The C-prefix mistag check (caught 1 bug in #134)
- The external codeset reference check (same drift potential as the others)

The two others from the review (\"no unreachable loop branches\", \"every required field has a meaningful default\") are vague enough to produce false positives without a clear win. Held for a follow-up if real cases motivate them.

## Verification
- [x] \`python tools/check_maps.py\` against current master: clean (32 files OK)
- [x] Sanity-tested with deliberately-injected bad ref: detected, exit 1
- [x] \`mypy --strict tools/check_maps.py\`: clean
- [x] \`ruff format --check\` + \`ruff check\` on \`tools/\`: clean
- [x] Existing 536 pytests: still pass

## Up next from the review

- **#4**: frozenset-backed code membership (~10 min)
- **#1**: pre-compiled IG maps as generated Python modules (~few days)
- **#2**: parser transition tables (held — needs profiler signal first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)