### PR TITLE
chore: O(N) -> O(1) code-list membership via frozenset

### DIFF
--- a/pyx12/codes.py
+++ b/pyx12/codes.py
@@ -31,7 +31,7 @@ class CodesError(Exception):
 class _CodeSet(TypedDict):
     name: str | None
     dataele: str | None
-    codes: list[str | None]
+    codes: frozenset[str | None]
 
 
 class ExternalCodes:
@@ -73,7 +73,7 @@ class ExternalCodes:
                 self.codes[codeset_id] = {
                     "name": cElem.findtext("name"),
                     "dataele": cElem.findtext("data_ele"),
-                    "codes": [c.text for c in cElem.iterfind("version/code")],
+                    "codes": frozenset(c.text for c in cElem.iterfind("version/code")),
                 }
 
     def isValid(self, key: str | None, code: str | None, check_dte: str | None = None) -> bool:
@@ -89,6 +89,6 @@ class ExternalCodes:
         return code in self.codes[key]["codes"]
 
     def debug_print(self, count: int = 10) -> None:
-        """Debug print first <count> codes for each codeset."""
+        """Debug print first <count> codes for each codeset (alphabetical)."""
         for key in self.codes:
-            print(self.codes[key]["codes"][:count])
+            print(sorted(self.codes[key]["codes"], key=lambda c: c or "")[:count])

--- a/pyx12/map_if/_element.py
+++ b/pyx12/map_if/_element.py
@@ -34,6 +34,7 @@ class element_if(x12_node):
     root: Any
     base_name: str
     valid_codes: list[str | None]
+    _valid_codes_set: frozenset[str | None]
     external_codes: str | None
     rec: re.Pattern[str] | None
     refdes: str | None
@@ -85,6 +86,10 @@ class element_if(x12_node):
             self.external_codes = v.get("external")
             for c in v.findall("code"):
                 self.valid_codes.append(c.text)
+        # Parallel frozenset for O(1) membership checks. The list is kept
+        # because callers (loop_if path disambiguation, map_if._get_icvn)
+        # rely on a stable indexed order from the XML.
+        self._valid_codes_set = frozenset(self.valid_codes)
 
     def debug_print(self) -> None:
         sys.stdout.write(self.__repr__())
@@ -126,9 +131,7 @@ class element_if(x12_node):
         :return: True if found, else False
         :rtype: boolean
         """
-        if code in self.valid_codes:
-            return True
-        return False
+        return code in self._valid_codes_set
 
     def get_parent(self) -> Any:
         """
@@ -322,9 +325,9 @@ class element_if(x12_node):
         :rtype: boolean
         """
         bValidCode = False
-        if len(self.valid_codes) == 0 and self.external_codes is None:
+        if not self._valid_codes_set and self.external_codes is None:
             bValidCode = True
-        if elem_val in self.valid_codes:
+        if elem_val in self._valid_codes_set:
             bValidCode = True
         if self.external_codes is not None and self.root.ext_codes.isValid(
             self.external_codes, elem_val

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -181,7 +181,7 @@ class segment_if(x12_node):
             return True
         child, ele_idx, subele_idx = key
         path = f"{ele_idx:02d}-{subele_idx}" if subele_idx else f"{ele_idx:02d}"
-        return seg.get_value(path) in child.valid_codes
+        return seg.get_value(path) in child._valid_codes_set
 
     def is_match_qual(
         self,
@@ -207,7 +207,7 @@ class segment_if(x12_node):
             return (True, None, None, None)
         child, ele_idx, subele_idx = key
         path = f"{ele_idx:02d}-{subele_idx}" if subele_idx else f"{ele_idx:02d}"
-        if qual_code in child.valid_codes and seg_data.get_value(path) == qual_code:
+        if qual_code in child._valid_codes_set and seg_data.get_value(path) == qual_code:
             return (True, qual_code, ele_idx, subele_idx)
         return (False, None, None, None)
 
@@ -310,7 +310,7 @@ class segment_if(x12_node):
             self.children[0].is_element()
             and self.children[0].get_data_type() == "ID"
             and len(self.children[0].valid_codes) > 0
-            and id_val in self.children[0].valid_codes
+            and id_val in self.children[0]._valid_codes_set
         ):
             return self.children[0]
         # Special Case for 820
@@ -319,21 +319,21 @@ class segment_if(x12_node):
             and self.children[1].is_element()
             and self.children[1].get_data_type() == "ID"
             and len(self.children[1].valid_codes) > 0
-            and id_val in self.children[1].valid_codes
+            and id_val in self.children[1]._valid_codes_set
         ):
             return self.children[1]
         elif (
             self.children[0].is_composite()
             and self.children[0].children[0].get_data_type() == "ID"
             and len(self.children[0].children[0].valid_codes) > 0
-            and id_val in self.children[0].children[0].valid_codes
+            and id_val in self.children[0].children[0]._valid_codes_set
         ):
             return self.children[0].children[0]
         elif (
             self.id == "HL"
             and self.children[2].is_element()
             and len(self.children[2].valid_codes) > 0
-            and id_val in self.children[2].valid_codes
+            and id_val in self.children[2]._valid_codes_set
         ):
             return self.children[2]
         return None


### PR DESCRIPTION
Recommendation #4 from the [architectural review](C:\Users\john\.claude\plans\starry-watching-sketch.md). Smallest performance change of the review's options; ~10 minutes of work.

## What changed

Three hot paths did linear scans against code lists:

| Site | Before | After |
|---|---|---|
| [\`element_if._is_valid_code\`](pyx12/map_if/_element.py) | \`elem_val in self.valid_codes\` (list) | \`elem_val in self._valid_codes_set\` (frozenset) |
| [\`segment_if.is_match\`/\`is_match_qual\`/\`get_unique_key_id_element\`](pyx12/map_if/_segment.py) — 6 call sites | \`qual_code in child.valid_codes\` (list) | \`qual_code in child._valid_codes_set\` (frozenset) |
| [\`ExternalCodes.isValid\`](pyx12/codes.py) | \`code in self.codes[key][\"codes\"]\` (list) | same expression but \`codes\` is now \`frozenset\` |

Per-list size is small (1-100 entries) but the `in` checks compound: every segment match attempt and every element validation across a long X12 file hits at least one of these.

## Why \`element_if.valid_codes\` keeps the list

Two callers still index it:
- [\`loop_if\` path disambiguation](pyx12/map_if/_loop.py#L82) uses \`id_elem.valid_codes[0]\` to build a unique segment path when ordinals collide
- [\`map_if._get_icvn\`](pyx12/map_if/_root.py#L86) reads \`node.valid_codes[0]\` to identify the interchange version

Both rely on a stable XML-order pick. So `element_if` now keeps the ordered list **and** has a parallel `_valid_codes_set` for fast membership.

## Why \`ExternalCodes.codes\` can flip directly

Only two callers ever access the \`[\"codes\"]\` field:
- The membership check in \`isValid\` (works fine on frozenset)
- A \`debug_print\` slice — switched to \`sorted(...)[:count]\` for stable output. (Different ordering than XML order, but it's debug output.)

No external API change.

## Verification
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean (frozenset is a TypedDict-compatible type)
- [x] \`ruff format --check\` + \`ruff check\` — clean
- [x] \`tools/check_maps.py\` — 32 maps clean

Net diff: +18 / -15 across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)