### PR TITLE
feat(scripts): list suppressible external code names in --help

### DIFF
--- a/pyx12/codes.py
+++ b/pyx12/codes.py
@@ -92,3 +92,29 @@ class ExternalCodes:
         """Debug print first <count> codes for each codeset (alphabetical)."""
         for key in self.codes:
             print(sorted(self.codes[key]["codes"], key=lambda c: c or "")[:count])
+
+
+def list_external_codesets(base_path: str | None = None) -> list[tuple[str, str]]:
+    """Return ``(id, name)`` for every codeset in ``codes.xml``.
+
+    Used by CLI scripts to populate ``--help`` with the list of names
+    accepted by the ``--exclude-external-codes`` flag. Loads the metadata
+    only — does not parse code values — so the cost is small.
+
+    :param base_path: Override directory containing codes.xml.
+        If None, uses package resource folder.
+    """
+    code_fd: IO[Any]
+    if base_path is not None:
+        code_fd = open(os.path.join(base_path, "codes.xml"), encoding="utf-8")
+    else:
+        code_fd = _res_files("pyx12").joinpath("map", "codes.xml").open("rb")
+    pairs: list[tuple[str, str]] = []
+    with code_fd:
+        parser = et.XMLParser(encoding="utf-8")
+        for cs in et.parse(code_fd, parser=parser).iter("codeset"):
+            cid = (cs.findtext("id") or "").strip()
+            name = (cs.findtext("name") or "").strip()
+            if cid:
+                pairs.append((cid, name))
+    return pairs

--- a/pyx12/scripts/__init__.py
+++ b/pyx12/scripts/__init__.py
@@ -1,0 +1,22 @@
+"""Helpers shared across the pyx12 CLI scripts."""
+
+from __future__ import annotations
+
+from pyx12.codes import list_external_codesets
+
+
+def external_codes_help_epilog() -> str:
+    """Build a `--help` epilog table listing names accepted by ``-x``.
+
+    Sourced from ``codes.xml`` so the table never drifts. Used by scripts
+    that expose ``--exclude-external-codes`` (x12valid, x12html, x12xml).
+    """
+    pairs = list_external_codesets()
+    width = max((len(cid) for cid, _ in pairs), default=0)
+    rows = "\n".join(f"  {cid:<{width}}  {name}" for cid, name in pairs)
+    return (
+        "External code names accepted by --exclude-external-codes / -x\n"
+        "(pass the flag once per name to suppress validation against that "
+        "codeset):\n\n"
+        f"{rows}"
+    )

--- a/pyx12/scripts/x12html.py
+++ b/pyx12/scripts/x12html.py
@@ -27,6 +27,7 @@ import sys
 import pyx12
 import pyx12.params
 import pyx12.x12n_document
+from pyx12.scripts import external_codes_help_epilog
 
 __author__ = pyx12.__author__
 __status__ = pyx12.__status__
@@ -49,7 +50,11 @@ def main():
     """
     Set up environment for processing
     """
-    parser = argparse.ArgumentParser(description="Format an X12 file as HTML")
+    parser = argparse.ArgumentParser(
+        description="Format an X12 file as HTML",
+        epilog=external_codes_help_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--config-file", "-c", action="store", dest="configfile", default=None)
     parser.add_argument("--log-file", "-l", action="store", dest="logfile", default=None)
     parser.add_argument(

--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -27,6 +27,7 @@ from os.path import isdir, isfile
 import pyx12
 import pyx12.params
 import pyx12.x12n_document
+from pyx12.scripts import external_codes_help_epilog
 
 __author__ = pyx12.__author__
 __status__ = pyx12.__status__
@@ -53,7 +54,11 @@ def main():
     """
     Set up environment for processing
     """
-    parser = argparse.ArgumentParser(description="X12 Validation")
+    parser = argparse.ArgumentParser(
+        description="X12 Validation",
+        epilog=external_codes_help_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--config-file", "-c", action="store", dest="configfile", default=None)
     parser.add_argument("--log-file", "-l", action="store", dest="logfile", default=None)
     parser.add_argument(

--- a/pyx12/scripts/x12xml.py
+++ b/pyx12/scripts/x12xml.py
@@ -26,6 +26,7 @@ from os.path import isdir, isfile
 import pyx12
 import pyx12.params
 import pyx12.x12n_document
+from pyx12.scripts import external_codes_help_epilog
 
 # Global Variables
 __author__ = pyx12.__author__
@@ -48,7 +49,11 @@ def check_map_path_arg(map_path):
 
 def main():
     """Script main program."""
-    parser = argparse.ArgumentParser(description="X12 to XML conversion")
+    parser = argparse.ArgumentParser(
+        description="X12 to XML conversion",
+        epilog=external_codes_help_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--config-file", "-c", action="store", dest="configfile", default=None)
     parser.add_argument("--log-file", "-l", action="store", dest="logfile", default=None)
     parser.add_argument(


### PR DESCRIPTION
The three CLI scripts that expose \`--exclude-external-codes\` / \`-x\` (x12valid, x12html, x12xml) now print a table of accepted code names as the argparse epilog. Sourced from \`codes.xml\` at parser construction so the table never drifts.

## Sample output (x12valid --help, tail)

\`\`\`
  -x EXCLUDE_EXTERNAL, --exclude-external-codes EXCLUDE_EXTERNAL
                        External Code Names to ignore
  --charset {b,e}, -s {b,e}
                        Specify X12 character set: b=basic, e=extended
  --version             show program's version number and exit

External code names accepted by --exclude-external-codes / -x
(pass the flag once per name to suppress validation against that codeset):

  states            US State or Province Codes
  country           Country Codes
  currency          Currency Code
  entity_id         Entity Identifier Code
  remark_code       Remark Code
  service_type      Service Type Code
  claim_status_cat  Health Care Claim Status Category Code (Code Source 507)
  claim_status      Health Care Claim Status Code (Code Source 508)
  pos               Place of Service - code source 237
\`\`\`

## Implementation

| File | Change |
|---|---|
| [\`pyx12/codes.py\`](pyx12/codes.py) | New \`list_external_codesets()\` returns \`(id, name)\` tuples by parsing \`codes.xml\` metadata only — no code-value loading |
| [\`pyx12/scripts/__init__.py\`](pyx12/scripts/__init__.py) | New \`external_codes_help_epilog()\` formats the table for argparse |
| [\`pyx12/scripts/x12valid.py\`](pyx12/scripts/x12valid.py), [\`x12html.py\`](pyx12/scripts/x12html.py), [\`x12xml.py\`](pyx12/scripts/x12xml.py) | Two-line change each: import the helper, pass it as \`epilog=\` with \`RawDescriptionHelpFormatter\` |

## Docs auto-update

The Sphinx CLI reference page ([\`docs/cli.rst\`](docs/cli.rst)) embeds each script's \`--help\` via \`literalinclude\` from \`docs/_generated/cli/<name>.txt\`. Those text files are regenerated by \`_capture_cli_help()\` in \`docs/conf.py\` on every docs build (and are gitignored), so the docs site picks up the new table automatically on the next docs CI run — no manual regeneration needed.

## Verification
- [x] \`python -m pyx12.scripts.x12valid --help\`: table renders correctly
- [x] Same for \`x12html\` and \`x12xml\`
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean
- [x] \`ruff format --check\` + \`ruff check\` — clean
- [x] \`tools/check_maps.py\` — 32 maps clean

Net diff: +66 / -3 across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)