### PR TITLE
fix(docs): capture --help in-process so RTD doesn't silently lose output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 """Sphinx configuration for pyx12 documentation."""
 
-import subprocess
+import importlib
 import sys
 from importlib.metadata import version as _get_version
 from pathlib import Path
@@ -25,11 +25,12 @@ extensions = [
 ]
 
 
-# Capture --help output for each console script using sys.executable so
-# Windows Smart App Control's reputation-based block on entry-point shims
-# (and Windows' CreateProcess PATH resolution differing from PATH search)
-# never matter. Output goes under docs/_generated/cli/ and is included by
-# docs/cli.rst via literalinclude.
+# Capture --help output for each console script by importing each module's
+# build_parser() and calling format_help() in-process. Previously this used
+# a subprocess with sys.executable, which silently produced empty .txt files
+# in environments where the subprocess Python could not import pyx12 (e.g.
+# Read the Docs). In-process import surfaces any failure as a Sphinx build
+# error instead of an empty <pre> block on the rendered page.
 _CLI_SCRIPTS = ("x12valid", "x12norm", "x12html", "x12info", "x12xml", "xmlx12")
 
 
@@ -37,19 +38,9 @@ def _capture_cli_help() -> None:
     out_dir = Path(__file__).parent / "_generated" / "cli"
     out_dir.mkdir(parents=True, exist_ok=True)
     for script in _CLI_SCRIPTS:
-        # Set sys.argv[0] before main() runs so argparse picks the entry-point
-        # name as prog (instead of "python.exe -m pyx12.scripts.x12norm").
-        runner = (
-            f"import sys; sys.argv = ['{script}', '--help']; "
-            f"from pyx12.scripts.{script} import main; main()"
-        )
-        result = subprocess.run(
-            [sys.executable, "-c", runner],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        (out_dir / f"{script}.txt").write_text(result.stdout, encoding="utf-8")
+        mod = importlib.import_module(f"pyx12.scripts.{script}")
+        parser = mod.build_parser()
+        (out_dir / f"{script}.txt").write_text(parser.format_help(), encoding="utf-8")
 
 
 _capture_cli_help()

--- a/pyx12/scripts/x12html.py
+++ b/pyx12/scripts/x12html.py
@@ -46,11 +46,10 @@ def check_map_path_arg(map_path):
     return map_path
 
 
-def main():
-    """
-    Set up environment for processing
-    """
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
     parser = argparse.ArgumentParser(
+        prog="x12html",
         description="Format an X12 file as HTML",
         epilog=external_codes_help_epilog(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -87,6 +86,14 @@ def main():
     )
     parser.add_argument("--version", action="version", version=f"{parser.prog} {__version__}")
     parser.add_argument("input_files", nargs="*")
+    return parser
+
+
+def main():
+    """
+    Set up environment for processing
+    """
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger("pyx12")

--- a/pyx12/scripts/x12info.py
+++ b/pyx12/scripts/x12info.py
@@ -29,8 +29,9 @@ def check_map_path_arg(map_path):
     return map_path
 
 
-def main():
-    parser = argparse.ArgumentParser(description="X12 File Metadata")
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
+    parser = argparse.ArgumentParser(prog="x12info", description="X12 File Metadata")
     parser.add_argument("--verbose", "-v", action="count", default=0)
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--debug", "-d", action="store_true")
@@ -54,6 +55,11 @@ def main():
     )
     parser.add_argument("--version", action="version", version=f"{parser.prog} {__version__}")
     parser.add_argument("input_files", nargs="*")
+    return parser
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger()

--- a/pyx12/scripts/x12norm.py
+++ b/pyx12/scripts/x12norm.py
@@ -23,8 +23,9 @@ __version__ = pyx12.__version__
 __date__ = pyx12.__date__
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Format an X12 document")
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
+    parser = argparse.ArgumentParser(prog="x12norm", description="Format an X12 document")
     parser.add_argument("--verbose", "-v", action="count", default=0)
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--debug", "-d", action="store_true")
@@ -45,6 +46,11 @@ def main():
     )
     parser.add_argument("--version", action="version", version=f"{parser.prog} {__version__}")
     parser.add_argument("input_files", nargs="*")
+    return parser
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger()

--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -50,11 +50,10 @@ def check_map_path_arg(map_path):
     return map_path
 
 
-def main():
-    """
-    Set up environment for processing
-    """
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
     parser = argparse.ArgumentParser(
+        prog="x12valid",
         description="X12 Validation",
         epilog=external_codes_help_epilog(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -79,14 +78,20 @@ def main():
     parser.add_argument(
         "--charset", "-s", choices=("b", "e"), help="Specify X12 character set: b=basic, e=extended"
     )
-    # parser.add_argument('--background', '-b', action='store_true')
-    # parser.add_argument('--test', '-t', action='store_true')
     parser.add_argument(
         "--version",
         action="version",
         version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_files", nargs="*")
+    return parser
+
+
+def main():
+    """
+    Set up environment for processing
+    """
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger("pyx12")

--- a/pyx12/scripts/x12xml.py
+++ b/pyx12/scripts/x12xml.py
@@ -47,9 +47,10 @@ def check_map_path_arg(map_path):
     return map_path
 
 
-def main():
-    """Script main program."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
     parser = argparse.ArgumentParser(
+        prog="x12xml",
         description="X12 to XML conversion",
         epilog=external_codes_help_epilog(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -75,14 +76,18 @@ def main():
     parser.add_argument(
         "--charset", "-s", choices=("b", "e"), help="Specify X12 character set: b=basic, e=extended"
     )
-    # parser.add_argument('--background', '-b', action='store_true')
-    # parser.add_argument('--test', '-t', action='store_true')
     parser.add_argument(
         "--version",
         action="version",
         version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_file")
+    return parser
+
+
+def main():
+    """Script main program."""
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger("pyx12")

--- a/pyx12/scripts/xmlx12.py
+++ b/pyx12/scripts/xmlx12.py
@@ -14,6 +14,7 @@
 Create an X12 document from a XML data file
 """
 
+import argparse
 import logging
 import sys
 
@@ -27,11 +28,9 @@ __version__ = pyx12.__version__
 __date__ = pyx12.__date__
 
 
-def main():
-    """Script main program."""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="XML to X12 conversion")
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Exposed so docs/conf.py can render --help."""
+    parser = argparse.ArgumentParser(prog="xmlx12", description="XML to X12 conversion")
     parser.add_argument("--log-file", "-l", action="store", dest="logfile", default=None)
     parser.add_argument("--verbose", "-v", action="count", default=0)
     parser.add_argument("--debug", "-d", action="store_true")
@@ -43,6 +42,12 @@ def main():
         version=f"{parser.prog} {__version__}",
     )
     parser.add_argument("input_file")
+    return parser
+
+
+def main():
+    """Script main program."""
+    parser = build_parser()
     args = parser.parse_args()
 
     logger = logging.getLogger("pyx12")


### PR DESCRIPTION
## Bug

https://pyx12.readthedocs.io/en/latest/cli.html had **empty \`<pre>\` blocks** for x12valid, x12html, x12info, and x12xml — even though the GitHub Actions docs job rendered them correctly. Latent since PR #110 introduced \`cli.rst\`; nobody noticed because the page rendered \"successfully\" with empty content.

## Cause

\`docs/conf.py\`'s \`_capture_cli_help()\` ran each script's \`--help\` in a subprocess (\`sys.executable -c \"from pyx12.scripts.X import main; main()\"\`) and wrote \`result.stdout\` to a \`.txt\` file. It **never checked the return code or stderr**. In Read the Docs' build environment the subprocess couldn't import \`pyx12.params\` — likely a \`sys.executable\` mismatch with where the editable install actually lived. Stdout was empty, the \`.txt\` was empty, the \`<pre>\` block was empty. The four scripts that import \`pyx12.params\` all failed silently; the two that don't (\`x12norm\`, \`xmlx12\`) worked.

## Fix

Each script now exposes a \`build_parser() -> ArgumentParser\` function. \`docs/conf.py\` imports those modules in-process and calls \`parser.format_help()\`:

\`\`\`python
def _capture_cli_help() -> None:
    out_dir = Path(__file__).parent / \"_generated\" / \"cli\"
    out_dir.mkdir(parents=True, exist_ok=True)
    for script in _CLI_SCRIPTS:
        mod = importlib.import_module(f\"pyx12.scripts.{script}\")
        parser = mod.build_parser()
        (out_dir / f\"{script}.txt\").write_text(parser.format_help(), encoding=\"utf-8\")
\`\`\`

Same Python interpreter, same env as Sphinx, no subprocess. Any import failure now raises during \`sphinx-build\` instead of producing a silent empty file.

Each \`build_parser()\` also passes \`prog=<script_name>\` so the captured \`--help\` is consistent regardless of how the parser is constructed.

## Files changed

| | |
|---|---|
| \`docs/conf.py\` | Drop subprocess; import & call \`build_parser()\` in-process |
| 6 × \`pyx12/scripts/X.py\` | Extract \`build_parser()\` from \`main()\` and pass \`prog=...\` |

\`main()\` behavior unchanged — it calls \`build_parser()\` then \`parser.parse_args()\`, same observable result.

## Verification

| | |
|---|---|
| Local re-capture | All 6 \`.txt\` files populate correctly (1443, 728, 669, 1386, 1492, 498 bytes) |
| \`pytest\` | 536 passed |
| \`mypy --strict\` | clean |
| \`ruff format --check\` + \`ruff check\` | clean |

Once this PR merges, RTD's next docs build will produce the correct \`cli.html\` with full \`--help\` output for all 6 scripts (including the new external-codes table from PR #139, which was getting suppressed by the same silent-failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)