### PR TITLE
fix(packaging): include pyx12.map_if in wheel; switch to packages.find

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,13 @@ x12norm = "pyx12.scripts.x12norm:main"
 x12xml = "pyx12.scripts.x12xml:main"
 xmlx12 = "pyx12.scripts.xmlx12:main"
 
-[tool.setuptools]
-packages = ["pyx12", "pyx12.scripts"]
+[tool.setuptools.packages.find]
+# Ship every pyx12 sub-package; exclude dev-only directories. Using `find`
+# (rather than an explicit list) so future sub-packages are picked up
+# automatically — the previous explicit list silently dropped pyx12.map_if
+# when it was added in PR #129, breaking `pip install` (RTD, PyPI release).
+include = ["pyx12", "pyx12.*"]
+exclude = ["pyx12.test*", "pyx12.tests*", "pyx12.examples*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.xml", "*.md"]


### PR DESCRIPTION
## What broke

The Read the Docs build for [\`dbe3704\` (PR #140's merge commit)](https://app.readthedocs.org/projects/pyx12/builds/32512566/) failed:

\`\`\`
File \".../pyx12/x12n_document.py\", line 29, in <module>
    import pyx12.map_if
ModuleNotFoundError: No module named 'pyx12.map_if'
\`\`\`

## Cause

\`pyproject.toml\`'s package list explicitly enumerated only \`[\"pyx12\", \"pyx12.scripts\"]\`. When [PR #129](https://github.com/azoner/pyx12/pull/129) converted \`map_if.py\` into a sub-package directory (\`pyx12/map_if/\`), nobody updated the list. The resulting wheel **silently drops** \`pyx12.map_if\`.

The bug was invisible to:
- **Local development** (editable installs via \`uv sync\` / \`pip install -e .\` mount the source tree, ignoring the packages list)
- **GitHub Actions docs CI** (also editable via \`uv sync --extra docs\`)
- **PyPI v3.1.0** (was tagged BEFORE PR #129)

But fatal to:
- **Read the Docs** (\`pip install . --extra-requirements docs\` in a clean env builds and installs a wheel — which is missing \`pyx12.map_if\`)
- **Any future PyPI release** (would have shipped a broken wheel)
- **Any \`pip install pyx12 @ git+https://...master\` since #129**

[PR #140](https://github.com/azoner/pyx12/pull/140) (the in-process help capture) didn't cause this — it surfaced it. Previously the same import failure happened inside a silent subprocess and the docs page just had empty \`<pre>\` blocks. Now it's a build error, as it should be.

## Fix

Switch to setuptools find-discovery so future sub-packages cannot be silently dropped:

\`\`\`toml
[tool.setuptools.packages.find]
include = [\"pyx12\", \"pyx12.*\"]
exclude = [\"pyx12.test*\", \"pyx12.tests*\", \"pyx12.examples*\"]
\`\`\`

This auto-includes \`pyx12.map_if\`, \`pyx12.scripts\`, and any future package (e.g. the proposed \`pyx12/map_if/_compiled/\` from [the architectural review](C:\Users\john\.claude\plans\starry-watching-sketch.md)) without manual maintenance.

## Verification

| Check | Result |
|---|---|
| \`python -m build --wheel\` | builds successfully |
| Wheel contains \`pyx12/map_if/__init__.py\` + \`_loader.py\` | ✓ |
| Wheel does NOT contain \`pyx12/test/*\`, \`pyx12/tests/*\`, \`pyx12/examples/*\` | ✓ |
| Fresh venv + \`pip install dist/*.whl\` + \`import pyx12.map_if\` from outside source tree | resolves to site-packages, \`load_map_file\` callable |
| \`pytest\` | 536 passed |
| \`mypy --strict\` | clean |
| \`ruff check\` | clean |
| \`tools/check_maps.py\` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)