### PR TITLE
chore: remove obsolete setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1


### PR DESCRIPTION
Single-line legacy file:

\`\`\`ini
[wheel]
universal = 1
\`\`\`

It was telling setuptools to tag the wheel as \`py2.py3-none-any\`. With \`requires-python = \">=3.11\"\` already in pyproject.toml, the py2 part was ceremony with no behavior — any py2 install attempt was rejected by metadata anyway. Last touched in 2018, before the py3 modernization push. Nothing in CI / docs / tooling references it.

## Effect on built wheels

| | Before | After |
|---|---|---|
| Wheel filename | \`pyx12-3.1.0-py2.py3-none-any.whl\` | \`pyx12-3.1.0-py3-none-any.whl\` |

The new tag accurately advertises what we ship.

## Verification
- [x] \`python -m build --wheel\` succeeds; filename matches the table above
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean
- [x] \`ruff check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)