### PR TITLE
chore: migrate MANIFEST.in into pyproject.toml package-data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include *.txt
-recursive-include pyx12 *.xml *.xsd README* *.dtd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ exclude = ["pyx12.test*", "pyx12.tests*", "pyx12.examples*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.xml", "*.md"]
-pyx12 = ["map/*.xml", "map/*.xsd"]
+pyx12 = ["map/*.xml", "map/*.xsd", "map/*.dtd", "map/README*"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Move file-inclusion patterns from \`MANIFEST.in\` into \`[tool.setuptools.package-data]\`. Single source of truth — matches the \`setup.cfg\` (#142) and \`.coveragerc\` (#143) migrations.

## Before

\`\`\`
# MANIFEST.in
include *.txt
recursive-include pyx12 *.xml *.xsd README* *.dtd
\`\`\`

\`\`\`toml
# pyproject.toml
[tool.setuptools.package-data]
\"*\" = [\"*.xml\", \"*.md\"]
pyx12 = [\"map/*.xml\", \"map/*.xsd\"]
\`\`\`

## After

\`\`\`toml
# pyproject.toml
[tool.setuptools.package-data]
\"*\" = [\"*.xml\", \"*.md\"]
pyx12 = [\"map/*.xml\", \"map/*.xsd\", \"map/*.dtd\", \"map/README*\"]
\`\`\`

\`MANIFEST.in\` deleted.

## What was actually load-bearing in MANIFEST.in

| Pattern | What it added | Migrated? |
|---|---|---|
| \`include *.txt\` | \`LICENSE.txt\` to sdist | Redundant — setuptools auto-includes LICENSE.txt from \`[project].license\` |
| \`recursive-include pyx12 *.xml *.xsd README* *.dtd\` | \`pyx12/map/README\` + \`pyx12/map/x12simple.dtd\` to sdist | Yes — added \`*.dtd\` and \`map/README*\` to package-data |

Verified by diffing sdist contents with vs without MANIFEST.in.

## Bonus: the wheel improves

Previously the DTD only shipped in the **sdist** because MANIFEST.in only affects sdist; \`package-data\` controls the wheel. After this PR, \`package-data\` covers it — so the **wheel** now ships \`pyx12/map/x12simple.dtd\` too. (Same for \`pyx12/map/README\`.) Strictly better.

## Verification
- [x] sdist: 108 files, includes \`pyx12/map/README\` + \`pyx12/map/x12simple.dtd\`
- [x] wheel: 98 files, **also** includes those two files (was missing them before)
- [x] \`pytest\` — 536 passed
- [x] \`mypy --strict\` — clean
- [x] \`ruff check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)