### PR TITLE
chore: remove obsolete RELEASE checklist

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,7 +1,0 @@
-# run unit tests
-# update version in pyproject.toml and pyx12/version.py
-# verify test is passing on Github
-# Create release and tag on Github
-# Verify PyPI release
-# Update venv
-# run functional tests


### PR DESCRIPTION
Seven-line manual release checklist last touched in 2024:

\`\`\`
# run unit tests
# update version in pyproject.toml and pyx12/version.py
# verify test is passing on Github
# Create release and tag on Github
# Verify PyPI release
# Update venv
# run functional tests
\`\`\`

The [\`/publish\` skill](.claude/skills/publish/SKILL.md) covers the substantive steps with concrete commands and per-target branches (testpypi vs production):

| RELEASE step | /publish covers it? |
|---|---|
| run unit tests | implicit — any non-passing local state should fail before \`/publish\` is invoked |
| update version | manual prerequisite either way |
| verify CI | manual prerequisite either way |
| Create release and tag on Github | step 7 (\`git tag\` + push) and step 8 (\`gh release create\`) |
| Verify PyPI release | step 6 reports the URL, step 6 has the install-verification one-liner for testpypi |
| Update venv | not specific to release |
| run functional tests | not specific to release |

The RELEASE file is a less-detailed duplicate. No CI, docs, or tooling references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)