### PR TITLE
refactor: element validators return EleError lists, no errh mutation

### DIFF
--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -12,6 +12,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from .errors import EngineError
 
 isa_errors = (
@@ -52,78 +54,34 @@ seg_errors = ("1", "2", "3", "4", "5", "6", "7", "8")
 ele_errors = ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
 
 
+@dataclass(slots=True, frozen=True)
 class ErrorItem:
-    """
-    Wrap an X12 validation error
-    """
-
     err_cde: str
     err_str: str
 
-    def __init__(self, err_type: str, err_cde: str, err_str: str) -> None:
-        """
-        :param err_type: At what level did the error occur
-        :type err_type: string
-        :param err_cde: Segment level error code
-        :type err_cde: string
-        :param err_str: Description of the error
-        :type err_str: string
-        """
-        self.err_cde = err_cde
-        self.err_str = err_str
 
-    def getErrCde(self) -> str:
-        return self.err_cde
-
-    def getErrStr(self) -> str:
-        return self.err_str
-
-
+@dataclass(slots=True, frozen=True)
 class ISAError(ErrorItem):
-    def __init__(self, err_cde: str, err_str: str) -> None:
-        ErrorItem.__init__(self, "isa", err_cde, err_str)
+    def __post_init__(self) -> None:
         if self.err_cde not in isa_errors:
             raise EngineError('Invalid ISA level error code "%s"' % (self.err_cde))
 
 
+@dataclass(slots=True, frozen=True)
 class SegError(ErrorItem):
-    err_val: str | None
+    err_val: str | None = None
+    src_line: int | None = None
 
-    def __init__(self, err_cde: str, err_str: str, err_val: str | None = None) -> None:
-        ErrorItem.__init__(self, "seg", err_cde, err_str)
-        self.err_val = err_val
+    def __post_init__(self) -> None:
         if self.err_cde not in seg_errors:
             raise EngineError('Invalid segment level error code "%s"' % (self.err_cde))
 
-    def getErrVal(self) -> str | None:
-        return self.err_val
 
-
+@dataclass(slots=True, frozen=True)
 class EleError(ErrorItem):
-    err_val: str | None
-    ele_idx: int | None
-    subele_idx: int | None
+    err_val: str | None = None
+    refdes: str | None = None
 
-    def __init__(
-        self,
-        err_cde: str,
-        err_str: str,
-        ele_idx: int | None,
-        subele_idx: int | None = None,
-        err_val: str | None = None,
-    ) -> None:
-        ErrorItem.__init__(self, "ele", err_cde, err_str)
-        self.err_val = err_val
-        self.ele_idx = ele_idx
-        self.subele_idx = subele_idx
+    def __post_init__(self) -> None:
         if self.err_cde not in ele_errors:
             raise EngineError('Invalid element level error code "%s"' % (self.err_cde))
-
-    def getErrVal(self) -> str | None:
-        return self.err_val
-
-    def getEleIdx(self) -> int | None:
-        return self.ele_idx
-
-    def getSubeleIdx(self) -> int | None:
-        return self.subele_idx

--- a/pyx12/map_if/_element.py
+++ b/pyx12/map_if/_element.py
@@ -19,6 +19,7 @@ from xml.etree.ElementTree import Element
 
 from .. import validation
 from ..dataele import _DataEle
+from ..error_item import EleError
 from ..errors import EngineError
 from ._base import _required_attr, x12_node
 
@@ -119,11 +120,8 @@ class element_if(x12_node):
             return self._data_ele
         return cast(_DataEle, self.root.data_elements.get_by_elem_num(self.data_ele))
 
-    def _error(self, errh: Any, err_str: str, err_cde: str, elem_val: str | None) -> None:
-        """
-        Forward the error to an error_handler
-        """
-        errh.ele_error(err_cde, err_str, elem_val, self.refdes)
+    def _ele_error(self, err_cde: str, err_str: str, err_val: str | None) -> EleError:
+        return EleError(err_cde=err_cde, err_str=err_str, err_val=err_val, refdes=self.refdes)
 
     def _valid_code(self, code: str | None) -> bool:
         """
@@ -149,55 +147,63 @@ class element_if(x12_node):
 
     def is_valid(self, elem: Any, errh: Any, type_list: list[str | None] | None = None) -> bool:
         """
-        Is this a valid element?
+        Backwards-compatible wrapper: drives the pure is_valid_errors and
+        forwards the produced errors into the legacy err_handler API.
+        """
+        errh.add_ele(self)
+        ok, errors = self.is_valid_errors(elem, type_list)
+        for e in errors:
+            errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
+        return ok
 
-        :param elem: element instance
-        :type elem: L{element<segment.Element>}
-        :param errh: instance of error_handler
-        :param type_list: Optional data/time type list
-        :type type_list: list[string]
-        :return: True if valid
-        :rtype: boolean
+    def is_valid_errors(
+        self, elem: Any, type_list: list[str | None] | None = None
+    ) -> tuple[bool, list[EleError]]:
+        """
+        Pure validator: returns (ok, errors) without touching an error handler.
         """
         if type_list is None:
             type_list = []
-        errh.add_ele(self)
+        errors: list[EleError] = []
 
         if elem and elem.is_composite():
             err_str = 'Data element "%s" (%s) is an invalid composite' % (self.name, self.refdes)
-            self._error(errh, err_str, "6", elem.__repr__())
-            return False
+            errors.append(self._ele_error("6", err_str, elem.__repr__()))
+            return False, errors
         if elem is None or elem.get_value() == "":
-            return self._validate_when_empty(errh)
+            empty_errors = self._validate_when_empty()
+            return (not empty_errors, empty_errors)
         if self.usage == "N" and elem.get_value() != "":
             err_str = 'Data element "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
-            self._error(errh, err_str, "10", None)
-            return False
+            errors.append(self._ele_error("10", err_str, None))
+            return False, errors
 
         elem_val = elem.get_value()
-        valid = self._validate_length(elem_val, errh)
-        if not self._validate_control_chars(elem_val, errh):
-            return False  # control char errors trump later checks
-        valid &= self._validate_trailing_spaces(elem_val, errh)
-        valid &= self._is_valid_code(elem_val, errh)
-        valid &= self._validate_data_type(elem_val, errh)
+        errors += self._validate_length(elem_val)
+        ctrl_errors = self._validate_control_chars(elem_val)
+        errors += ctrl_errors
+        if ctrl_errors:
+            # control char errors trump later checks
+            return False, errors
+        errors += self._validate_trailing_spaces(elem_val)
+        errors += self._is_valid_code(elem_val)
+        errors += self._validate_data_type(elem_val)
         if type_list:
-            valid &= self._validate_type_list(elem_val, type_list, errh)
-        valid &= self._validate_regex(elem_val, errh)
-        return bool(valid)
+            errors += self._validate_type_list(elem_val, type_list)
+        errors += self._validate_regex(elem_val)
+        return (not errors, errors)
 
-    def _validate_when_empty(self, errh: Any) -> bool:
+    def _validate_when_empty(self) -> list[EleError]:
         if self.usage in ("N", "S"):
-            return True
+            return []
         if self.usage == "R" and (
             self.seq != 1 or not self.parent.is_composite() or self.parent.usage == "R"
         ):
             err_str = 'Mandatory data element "%s" (%s) is missing' % (self.name, self.refdes)
-            self._error(errh, err_str, "1", None)
-            return False
-        return True
+            return [self._ele_error("1", err_str, None)]
+        return []
 
-    def _validate_length(self, elem_val: str, errh: Any) -> bool:
+    def _validate_length(self, elem_val: str) -> list[EleError]:
         data_ele = self._resolve_data_ele()
         data_type = data_ele["data_type"]
         min_len = data_ele["min_len"]
@@ -208,7 +214,7 @@ class element_if(x12_node):
         else:
             measured = elem_val
         elem_len = len(measured)
-        valid = True
+        out: list[EleError] = []
         if elem_len < min_len:
             err_str = 'Data element "%s" (%s) is too short: len("%s") = %i < %i (min_len)' % (
                 self.name,
@@ -217,8 +223,7 @@ class element_if(x12_node):
                 elem_len,
                 min_len,
             )
-            self._error(errh, err_str, "4", elem_val)
-            valid = False
+            out.append(self._ele_error("4", err_str, elem_val))
         if elem_len > max_len:
             err_str = 'Data element "%s" (%s) is too long: len("%s") = %i > %i (max_len)' % (
                 self.name,
@@ -227,67 +232,64 @@ class element_if(x12_node):
                 elem_len,
                 max_len,
             )
-            self._error(errh, err_str, "5", elem_val)
-            valid = False
-        return valid
+            out.append(self._ele_error("5", err_str, elem_val))
+        return out
 
-    def _validate_control_chars(self, elem_val: str, errh: Any) -> bool:
+    def _validate_control_chars(self, elem_val: str) -> list[EleError]:
         res, bad_string = validation.contains_control_character(elem_val)
         if not res:
-            return True
+            return []
         err_str = 'Data element "%s" (%s), contains an invalid control character(%s)' % (
             self.name,
             self.refdes,
             bad_string,
         )
-        self._error(errh, err_str, "6", bad_string)
-        return False
+        return [self._ele_error("6", err_str, bad_string)]
 
-    def _validate_trailing_spaces(self, elem_val: str, errh: Any) -> bool:
+    def _validate_trailing_spaces(self, elem_val: str) -> list[EleError]:
         data_ele = self._resolve_data_ele()
         if data_ele["data_type"] not in ("AN", "ID") or elem_val[-1] != " ":
-            return True
+            return []
         if len(elem_val.rstrip()) < data_ele["min_len"]:
-            return True
+            return []
         err_str = 'Data element "%s" (%s) has unnecessary trailing spaces. (%s)' % (
             self.name,
             self.refdes,
             elem_val,
         )
-        self._error(errh, err_str, "6", elem_val)
-        return False
+        return [self._ele_error("6", err_str, elem_val)]
 
-    def _validate_data_type(self, elem_val: str, errh: Any) -> bool:
+    def _validate_data_type(self, elem_val: str) -> list[EleError]:
         data_type = self._resolve_data_ele()["data_type"]
         if validation.IsValidDataType(
             elem_val, cast(str, data_type), self.root.param.get("charset"), self.root.icvn
         ):
-            return True
+            return []
         if data_type in ("RD8", "DT", "D8", "D6"):
             err_str = 'Data element "%s" (%s) contains an invalid date (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            self._error(errh, err_str, "8", elem_val)
-        elif data_type == "TM":
+            return [self._ele_error("8", err_str, elem_val)]
+        if data_type == "TM":
             err_str = 'Data element "%s" (%s) contains an invalid time (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            self._error(errh, err_str, "9", elem_val)
-        else:
-            err_str = 'Data element "%s" (%s) is type %s, contains an invalid character(%s)' % (
-                self.name,
-                self.refdes,
-                data_type,
-                elem_val,
-            )
-            self._error(errh, err_str, "6", elem_val)
-        return False
+            return [self._ele_error("9", err_str, elem_val)]
+        err_str = 'Data element "%s" (%s) is type %s, contains an invalid character(%s)' % (
+            self.name,
+            self.refdes,
+            data_type,
+            elem_val,
+        )
+        return [self._ele_error("6", err_str, elem_val)]
 
-    def _validate_type_list(self, elem_val: str, type_list: list[str | None], errh: Any) -> bool:
+    def _validate_type_list(
+        self, elem_val: str, type_list: list[str | None]
+    ) -> list[EleError]:
         valid_type = False
         for dtype in type_list:
             if dtype is not None:
@@ -295,49 +297,41 @@ class element_if(x12_node):
                     elem_val, dtype, self.root.param.get("charset")
                 )
         if valid_type:
-            return True
+            return []
         if "TM" in type_list:
             err_str = 'Data element "%s" (%s) contains an invalid time (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            self._error(errh, err_str, "9", elem_val)
-        elif any(t in type_list for t in ("RD8", "DT", "D8", "D6")):
+            return [self._ele_error("9", err_str, elem_val)]
+        if any(t in type_list for t in ("RD8", "DT", "D8", "D6")):
             err_str = 'Data element "%s" (%s) contains an invalid date (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            self._error(errh, err_str, "8", elem_val)
-        return False
+            return [self._ele_error("8", err_str, elem_val)]
+        return []
 
-    def _validate_regex(self, elem_val: str, errh: Any) -> bool:
+    def _validate_regex(self, elem_val: str) -> list[EleError]:
         if self.rec is None or self.rec.search(elem_val):
-            return True
+            return []
         err_str = 'Data element "%s" with a value of (%s)' % (self.name, elem_val)
         err_str += ' failed to match the regular expression "%s"' % (self.res)
-        self._error(errh, err_str, "7", elem_val)
-        return False
+        return [self._ele_error("7", err_str, elem_val)]
 
-    def _is_valid_code(self, elem_val: str, errh: Any) -> bool:
-        """
-        :rtype: boolean
-        """
-        bValidCode = False
+    def _is_valid_code(self, elem_val: str) -> list[EleError]:
         if not self._valid_codes_set and self.external_codes is None:
-            bValidCode = True
+            return []
         if elem_val in self._valid_codes_set:
-            bValidCode = True
+            return []
         if self.external_codes is not None and self.root.ext_codes.isValid(
             self.external_codes, elem_val
         ):
-            bValidCode = True
-        if not bValidCode:
-            err_str = "(%s) is not a valid code for %s (%s)" % (elem_val, self.name, self.refdes)
-            self._error(errh, err_str, "7", elem_val)
-            return False
-        return True
+            return []
+        err_str = "(%s) is not a valid code for %s (%s)" % (elem_val, self.name, self.refdes)
+        return [self._ele_error("7", err_str, elem_val)]
 
     def get_data_type(self) -> str | None:
         return self._resolve_data_ele()["data_type"]

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -399,7 +399,11 @@ class segment_if(x12_node):
                 elif child_node.data_ele == "1251" and len(type_list) > 0:
                     valid &= child_node.is_valid(ele_data, errh, type_list)
                 else:
-                    valid &= child_node.is_valid(ele_data, errh)
+                    errh.add_ele(child_node)
+                    ok, ele_errors = child_node.is_valid_errors(ele_data)
+                    for e in ele_errors:
+                        errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
+                    valid &= ok
 
         for i in range(min(len(seg_data), child_count), child_count):
             # missing required elements?

--- a/pyx12/test/test_error_item.py
+++ b/pyx12/test/test_error_item.py
@@ -6,24 +6,24 @@ from pyx12.errors import EngineError
 
 class TestErrorItem(unittest.TestCase):
     def test_basic_creation(self):
-        e = ErrorItem("isa", "001", "some error")
-        self.assertEqual(e.getErrCde(), "001")
-        self.assertEqual(e.getErrStr(), "some error")
+        e = ErrorItem("001", "some error")
+        self.assertEqual(e.err_cde, "001")
+        self.assertEqual(e.err_str, "some error")
 
 
 class TestISAError(unittest.TestCase):
     def test_valid_code(self):
         e = ISAError("001", "ISA segment error")
-        self.assertEqual(e.getErrCde(), "001")
-        self.assertEqual(e.getErrStr(), "ISA segment error")
+        self.assertEqual(e.err_cde, "001")
+        self.assertEqual(e.err_str, "ISA segment error")
 
     def test_valid_code_000(self):
         e = ISAError("000", "no error")
-        self.assertEqual(e.getErrCde(), "000")
+        self.assertEqual(e.err_cde, "000")
 
     def test_valid_code_031(self):
         e = ISAError("031", "last valid code")
-        self.assertEqual(e.getErrCde(), "031")
+        self.assertEqual(e.err_cde, "031")
 
     def test_invalid_code_raises(self):
         with self.assertRaises(EngineError):
@@ -37,20 +37,20 @@ class TestISAError(unittest.TestCase):
 class TestSegError(unittest.TestCase):
     def test_valid_code(self):
         e = SegError("1", "segment error")
-        self.assertEqual(e.getErrCde(), "1")
-        self.assertEqual(e.getErrStr(), "segment error")
+        self.assertEqual(e.err_cde, "1")
+        self.assertEqual(e.err_str, "segment error")
 
     def test_valid_code_8(self):
         e = SegError("8", "seg error")
-        self.assertEqual(e.getErrCde(), "8")
+        self.assertEqual(e.err_cde, "8")
 
     def test_err_val_default_none(self):
         e = SegError("1", "seg error")
-        self.assertIsNone(e.getErrVal())
+        self.assertIsNone(e.err_val)
 
     def test_err_val_set(self):
         e = SegError("2", "seg error", err_val="BAD*SEG")
-        self.assertEqual(e.getErrVal(), "BAD*SEG")
+        self.assertEqual(e.err_val, "BAD*SEG")
 
     def test_invalid_code_raises(self):
         with self.assertRaises(EngineError):
@@ -63,41 +63,37 @@ class TestSegError(unittest.TestCase):
 
 class TestEleError(unittest.TestCase):
     def test_valid_code(self):
-        e = EleError("1", "element error", ele_idx=1)
-        self.assertEqual(e.getErrCde(), "1")
-        self.assertEqual(e.getErrStr(), "element error")
+        e = EleError("1", "element error")
+        self.assertEqual(e.err_cde, "1")
+        self.assertEqual(e.err_str, "element error")
 
     def test_valid_code_10(self):
-        e = EleError("10", "element error", ele_idx=5)
-        self.assertEqual(e.getErrCde(), "10")
+        e = EleError("10", "element error")
+        self.assertEqual(e.err_cde, "10")
 
-    def test_ele_idx(self):
-        e = EleError("1", "element error", ele_idx=3)
-        self.assertEqual(e.getEleIdx(), 3)
+    def test_refdes_default_none(self):
+        e = EleError("1", "element error")
+        self.assertIsNone(e.refdes)
 
-    def test_subele_idx_default_none(self):
-        e = EleError("1", "element error", ele_idx=1)
-        self.assertIsNone(e.getSubeleIdx())
-
-    def test_subele_idx_set(self):
-        e = EleError("1", "element error", ele_idx=2, subele_idx=1)
-        self.assertEqual(e.getSubeleIdx(), 1)
+    def test_refdes_set(self):
+        e = EleError("1", "element error", refdes="03")
+        self.assertEqual(e.refdes, "03")
 
     def test_err_val_default_none(self):
-        e = EleError("1", "element error", ele_idx=1)
-        self.assertIsNone(e.getErrVal())
+        e = EleError("1", "element error")
+        self.assertIsNone(e.err_val)
 
     def test_err_val_set(self):
-        e = EleError("2", "element error", ele_idx=1, err_val="BADVAL")
-        self.assertEqual(e.getErrVal(), "BADVAL")
+        e = EleError("2", "element error", err_val="BADVAL")
+        self.assertEqual(e.err_val, "BADVAL")
 
     def test_invalid_code_raises(self):
         with self.assertRaises(EngineError):
-            EleError("11", "bad code", ele_idx=1)
+            EleError("11", "bad code")
 
     def test_invalid_code_zero(self):
         with self.assertRaises(EngineError):
-            EleError("0", "bad code", ele_idx=1)
+            EleError("0", "bad code")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Phase 1 of producer-side functionalization (see `.claude/plans/radiant-petting-steele.md`) — move element validators away from mutating an `err_handler` instance toward pure functions that return `(bool, list[EleError])`.

- **`pyx12/error_item.py`** — `ErrorItem` and subclasses are now `@dataclass(slots=True, frozen=True)`. Per-level code validation moves into `__post_init__`. `EleError` gains `refdes` (matches `errh.ele_error`'s producer signature) and sheds dead `ele_idx`/`subele_idx` fields — they were never set by running code, only by tests. `SegError` gains `src_line` for parity with `errh.seg_error`.
- **`pyx12/map_if/_element.py`** — new `is_valid_errors(elem, type_list=None) -> tuple[bool, list[EleError]]` is the pure validator. Seven `_validate_*` helpers plus `_is_valid_code` and `_validate_when_empty` now return `list[EleError]` instead of taking `errh` and returning `bool`. Old `is_valid(elem, errh, type_list=None) -> bool` is kept as a thin wrapper that calls `is_valid_errors`, forwards errors via `errh.add_ele` + `errh.ele_error`, and returns the bool. **All current callers and tests untouched** by design.
- **`pyx12/map_if/_segment.py:402-407`** — one leaf-element call site switched to `is_valid_errors` to prove the parent-aggregator pattern. The three adjacent element sites (DTP date type, 1251 type list, missing required) and the helper extraction land in Phase 2.
- **`pyx12/test/test_error_item.py`** — direct attribute access (the `get*` accessors are gone) and the new `EleError` signature; `refdes` tests replace the dead `ele_idx`/`subele_idx` tests.

Test count goes 536 → 535 because `ele_idx`/`subele_idx` removal drops their dedicated test.

## Why hybrid (not full flat-list)

997/999 acks are themselves ISA/GS/ST-framed X12 documents — visitor-traversal of the `err_handler` tree is the natural shape for emitting envelope segments. The producer end is where `errh` mutation conflated three concerns (validity, reporting, cursor maintenance); that's what this refactor addresses. The half-baked `errh_list` flat-list at `pyx12/error_handler.py:1179-1358` proved full flattening breaks ack writers.

## Test plan

- [x] `pytest pyx12/test/` passes (535/535 — was 536; one dead-field test dropped, see above)
- [x] `pytest pyx12/test/test_error_item.py` passes (20/20 with new dataclass shape)
- [x] `pytest pyx12/test/test_map_if.py` passes (67/67 — element validation paths still behave identically through the wrapper)
- [ ] CI green
- [ ] `check_maps` CI gate green

## Phase plan (for context — out of scope here)

- Phase 2: refactor `_composite.py` + remaining `_segment.py` element sites; extract aggregator helper.
- Phase 3: walker (`map_walker.py`) + syntax (already pure).
- Phase 4: retire `errh_null` test stub; reconsider `errh_list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)