### PR TITLE
refactor: composite/segment drive element validation via is_valid_errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,6 @@ See the [/test](.claude/commands/test.md) skill for invocation, reporting, and a
 
 ## Preferences
 - Save preferences to this CLAUDE.md file so they persist across sessions
+- No pickle / opaque deserialization for shipped or loaded artifacts — prefer generated `.py` modules (security: `__reduce__` is an arbitrary-code-execution surface unacceptable in a healthcare-data library)
+- Every production release tag (`vN.N.N`) needs a matching `gh release create --latest` after the PyPI upload step
+- Keep unreachable safety-net `return` statements in walker `while True` loops — they document intent and protect against future control-flow changes

--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from .errors import EngineError
 
@@ -81,6 +82,11 @@ class SegError(ErrorItem):
 class EleError(ErrorItem):
     err_val: str | None = None
     refdes: str | None = None
+    # map_node carries the element node ref for cursor materialization in the
+    # err_handler tree. None means the wrapper should leave the cursor where
+    # it was (used for composite-/seg-level errors that historically attach
+    # to the prior cursor).
+    map_node: Any = None
 
     def __post_init__(self) -> None:
         if self.err_cde not in ele_errors:

--- a/pyx12/map_if/_composite.py
+++ b/pyx12/map_if/_composite.py
@@ -16,8 +16,9 @@ import sys
 from typing import Any
 from xml.etree.ElementTree import Element
 
+from ..error_item import EleError
 from ._base import _required_attr, x12_node
-from ._element import element_if
+from ._element import apply_element_errors, element_if
 
 
 ############################################################
@@ -137,12 +138,59 @@ class composite_if(x12_node):
             errh.ele_error("3", err_str, None, self.refdes)
             valid = False
         for i in range(min(len(comp_data), self.get_child_count())):
-            valid &= self.get_child_node_by_idx(i).is_valid(comp_data[i], errh)
+            valid &= apply_element_errors(self.get_child_node_by_idx(i), comp_data[i], errh)
         for i in range(min(len(comp_data), self.get_child_count()), self.get_child_count()):
             if i < self.get_child_count():
                 # Check missing required elements
-                valid &= self.get_child_node_by_idx(i).is_valid(None, errh)
+                valid &= apply_element_errors(self.get_child_node_by_idx(i), None, errh)
         return valid
+
+    def is_valid_errors(self, comp_data: Any) -> tuple[bool, list[EleError]]:
+        """
+        Pure validator parallel to is_valid: returns (ok, errors) without
+        touching an error handler. Composite-level errors leave map_node
+        unset (=None), so a wrapper iterating with cursor tracking will
+        attach them to whatever cursor was last set — matches the historical
+        behavior of the errh.ele_error calls in is_valid.
+        """
+        valid = True
+        errors: list[EleError] = []
+
+        if (comp_data is None or comp_data.is_empty()) and self.usage in ("N", "S"):
+            return True, []
+
+        if self.usage == "R":
+            good_flag = False
+            if comp_data is not None:
+                for sub_ele in comp_data:
+                    if sub_ele is not None and len(sub_ele.get_value()) > 0:
+                        good_flag = True
+                        break
+            if not good_flag:
+                err_str = 'At least one component of composite "%s" (%s) is required' % (
+                    self.name,
+                    self.refdes,
+                )
+                return False, [EleError(err_cde="2", err_str=err_str, refdes=self.refdes)]
+
+        if self.usage == "N" and not comp_data.is_empty():
+            err_str = 'Composite "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
+            return False, [EleError(err_cde="5", err_str=err_str, refdes=self.refdes)]
+
+        if len(comp_data) > self.get_child_count():
+            err_str = 'Too many sub-elements in composite "%s" (%s)' % (self.name, self.refdes)
+            errors.append(EleError(err_cde="3", err_str=err_str, refdes=self.refdes))
+            valid = False
+        for i in range(min(len(comp_data), self.get_child_count())):
+            ok, sub_errors = self.get_child_node_by_idx(i).is_valid_errors(comp_data[i])
+            valid &= ok
+            errors += sub_errors
+        for i in range(min(len(comp_data), self.get_child_count()), self.get_child_count()):
+            if i < self.get_child_count():
+                ok, sub_errors = self.get_child_node_by_idx(i).is_valid_errors(None)
+                valid &= ok
+                errors += sub_errors
+        return valid, errors
 
     def is_composite(self) -> bool:
         """

--- a/pyx12/map_if/_element.py
+++ b/pyx12/map_if/_element.py
@@ -24,6 +24,22 @@ from ..errors import EngineError
 from ._base import _required_attr, x12_node
 
 
+def apply_element_errors(
+    child_node: element_if,
+    ele_data: Any,
+    errh: Any,
+    type_list: list[str | None] | None = None,
+) -> bool:
+    """Drive an element validation: set the cursor, run is_valid_errors,
+    forward errors. Used by composite and segment wrappers to bridge from
+    the pure validator surface back to the err_handler API."""
+    errh.add_ele(child_node)
+    ok, errors = child_node.is_valid_errors(ele_data, type_list)
+    for e in errors:
+        errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
+    return ok
+
+
 ############################################################
 # Element Interface
 ############################################################
@@ -121,7 +137,13 @@ class element_if(x12_node):
         return cast(_DataEle, self.root.data_elements.get_by_elem_num(self.data_ele))
 
     def _ele_error(self, err_cde: str, err_str: str, err_val: str | None) -> EleError:
-        return EleError(err_cde=err_cde, err_str=err_str, err_val=err_val, refdes=self.refdes)
+        return EleError(
+            err_cde=err_cde,
+            err_str=err_str,
+            err_val=err_val,
+            refdes=self.refdes,
+            map_node=self,
+        )
 
     def _valid_code(self, code: str | None) -> bool:
         """
@@ -287,9 +309,7 @@ class element_if(x12_node):
         )
         return [self._ele_error("6", err_str, elem_val)]
 
-    def _validate_type_list(
-        self, elem_val: str, type_list: list[str | None]
-    ) -> list[EleError]:
+    def _validate_type_list(self, elem_val: str, type_list: list[str | None]) -> list[EleError]:
         valid_type = False
         for dtype in type_list:
             if dtype is not None:

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -19,12 +19,13 @@ from xml.etree.ElementTree import Element
 
 import pyx12.segment
 
+from ..error_item import EleError
 from ..errors import EngineError
 from ..path import X12Path
 from ..syntax import is_syntax_valid
 from ._base import MAXINT, _required_attr, x12_node
 from ._composite import composite_if
-from ._element import element_if
+from ._element import apply_element_errors, element_if
 
 
 class segment_if(x12_node):
@@ -395,20 +396,19 @@ class segment_if(x12_node):
                     type_list.extend(child_node.valid_codes)
                 ele_data = seg_data.get("%02i" % (i + 1))
                 if i == 2 and seg_data.get_seg_id() == "DTP":
-                    valid &= child_node.is_valid(ele_data, errh, dtype)
+                    valid &= apply_element_errors(child_node, ele_data, errh, dtype)
                 elif child_node.data_ele == "1251" and len(type_list) > 0:
-                    valid &= child_node.is_valid(ele_data, errh, type_list)
+                    valid &= apply_element_errors(child_node, ele_data, errh, type_list)
                 else:
-                    errh.add_ele(child_node)
-                    ok, ele_errors = child_node.is_valid_errors(ele_data)
-                    for e in ele_errors:
-                        errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
-                    valid &= ok
+                    valid &= apply_element_errors(child_node, ele_data, errh)
 
         for i in range(min(len(seg_data), child_count), child_count):
             # missing required elements?
             child_node = self.get_child_node_by_idx(i)
-            valid &= child_node.is_valid(None, errh)
+            if child_node.is_composite():
+                valid &= child_node.is_valid(None, errh)
+            else:
+                valid &= apply_element_errors(child_node, None, errh)
 
         for syn in self.syntax:
             (bResult, syn_err) = is_syntax_valid(seg_data, syn)
@@ -421,6 +421,93 @@ class segment_if(x12_node):
                 valid &= False
 
         return valid
+
+    def is_valid_errors(self, seg_data: pyx12.segment.Segment) -> tuple[bool, list[EleError]]:
+        """
+        Pure validator parallel to is_valid: returns (ok, errors) without
+        touching an error handler. Seg-level errors (too many elements,
+        too many sub-elements, syntax) leave map_node unset (=None);
+        per-element errors carry map_node from the element validator so
+        a cursor-tracking wrapper can replay add_ele/ele_error in the
+        original order.
+        """
+        valid = True
+        errors: list[EleError] = []
+        child_count = self.get_child_count()
+
+        if len(seg_data) > child_count:
+            err_str = 'Too many elements in segment "%s" (%s). Has %i, should have %i' % (
+                self.name,
+                seg_data.get_seg_id(),
+                len(seg_data),
+                child_count,
+            )
+            ref_des = "%02i" % (child_count + 1)
+            err_value = seg_data.get_value(ref_des)
+            errors.append(EleError(err_cde="3", err_str=err_str, err_val=err_value, refdes=ref_des))
+            valid = False
+
+        dtype: list[str | None] = []
+        type_list: list[str | None] = []
+        for i in range(min(len(seg_data), child_count)):
+            child_node = self.get_child_node_by_idx(i)
+            if child_node.is_composite():
+                ref_des = "%02i" % (i + 1)
+                comp_data = seg_data.get(ref_des)
+                subele_count = child_node.get_child_count()
+                if seg_data.ele_len(ref_des) > subele_count and child_node.usage != "N":
+                    subele_node = child_node.get_child_node_by_idx(subele_count + 1)
+                    err_str = 'Too many sub-elements in composite "%s" (%s)' % (
+                        subele_node.name,
+                        subele_node.refdes,
+                    )
+                    err_value = seg_data.get_value(ref_des)
+                    errors.append(
+                        EleError(
+                            err_cde="3",
+                            err_str=err_str,
+                            err_val=err_value,
+                            refdes=ref_des,
+                        )
+                    )
+                ok, comp_errors = child_node.is_valid_errors(comp_data)
+                valid &= ok
+                errors += comp_errors
+            elif child_node.is_element():
+                if (
+                    i == 1
+                    and seg_data.get_seg_id() == "DTP"
+                    and seg_data.get_value("02") in ("RD8", "D8", "D6", "DT", "TM")
+                ):
+                    dtype = [seg_data.get_value("02")]
+                if child_node.data_ele == "1250":
+                    type_list.extend(child_node.valid_codes)
+                ele_data = seg_data.get("%02i" % (i + 1))
+                if i == 2 and seg_data.get_seg_id() == "DTP":
+                    ok, ele_errors = child_node.is_valid_errors(ele_data, dtype)
+                elif child_node.data_ele == "1251" and len(type_list) > 0:
+                    ok, ele_errors = child_node.is_valid_errors(ele_data, type_list)
+                else:
+                    ok, ele_errors = child_node.is_valid_errors(ele_data)
+                valid &= ok
+                errors += ele_errors
+
+        for i in range(min(len(seg_data), child_count), child_count):
+            child_node = self.get_child_node_by_idx(i)
+            ok, child_errors = child_node.is_valid_errors(None)
+            valid &= ok
+            errors += child_errors
+
+        for syn in self.syntax:
+            bResult, syn_err = is_syntax_valid(seg_data, syn)
+            if not bResult:
+                # When is_syntax_valid returns False, syn_err is the message string.
+                assert syn_err is not None
+                code = "10" if syn[0] == "E" else "2"
+                errors.append(EleError(err_cde=code, err_str=syn_err, refdes=syn[1]))
+                valid = False
+
+        return valid, errors
 
     def _split_syntax(self, syntax: str | None) -> list[Any] | None:
         """


### PR DESCRIPTION
## Summary

Phase 2 first slice of producer-side functionalization (see `.claude/plans/radiant-petting-steele.md`). The production path
(`x12n_document.py:207` → `segment_if.is_valid` → `composite_if.is_valid`) now drives every element validation through the pure `element_if.is_valid_errors` surface introduced in #147. No more `errh`-mutating element wrapper calls inside composite or segment.

- **`pyx12/error_item.py`** — `EleError` gains `map_node: Any = None`. Carries the validator node ref so a cursor-tracking wrapper can replay `errh.add_ele(map_node)` before forwarding. Composite- and seg-level errors leave it `None`, preserving the historical "attach to prior cursor" behavior.
- **`pyx12/map_if/_element.py`** — new module-level `apply_element_errors(child_node, ele_data, errh, type_list=None) -> bool` aggregator. Sets the cursor, runs `is_valid_errors`, forwards each returned `EleError` via `errh.ele_error`. The `_ele_error` helper now sets `map_node=self` on every `EleError`.
- **`pyx12/map_if/_segment.py`** — all four element call sites in the wrapper (DTP date type, 1251 type list, plain element, missing required) go through `apply_element_errors`. The composite call site still uses the composite wrapper. Adds a parallel pure `is_valid_errors(seg_data) -> tuple[bool, list[EleError]]` (added for the next slice; not yet used in production).
- **`pyx12/map_if/_composite.py`** — both sub-element call sites in `is_valid` switch to `apply_element_errors`. Adds a parallel pure `is_valid_errors(comp_data) -> tuple[bool, list[EleError]]`.

## Scope split

The original Phase 2 plan also called for deleting the element + composite wrappers and migrating ~22 dependent tests. That gets a second slice to keep this PR review-sized; wrappers stay as test compat shims for now. The pure `is_valid_errors` methods are added on composite + segment in this slice so the next slice can swap callers without further refactoring.

## Test plan

- [x] `pytest pyx12/test/` — 535/535 pass
- [x] `mypy --strict pyx12/` — clean across all 82 source files
- [x] `ruff format` + `ruff check` — clean
- [ ] CI green
- [ ] `check_maps` CI gate green

## Note

This PR includes one extra commit, `6b28f4e` (`docs: add security, release, and walker preferences to CLAUDE.md`), which was committed locally to master before branching. Either push `master` to `origin` separately (and the PR will reduce to one commit) or merge via PR (both commits land together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)