### PR TITLE
refactor: delete composite_if.is_valid wrapper, switch to apply_composite_errors

### DIFF
--- a/pyx12/map_if/_composite.py
+++ b/pyx12/map_if/_composite.py
@@ -18,7 +18,23 @@ from xml.etree.ElementTree import Element
 
 from ..error_item import EleError
 from ._base import _required_attr, x12_node
-from ._element import apply_element_errors, element_if
+from ._element import element_if
+
+
+def apply_composite_errors(child_node: composite_if, comp_data: Any, errh: Any) -> bool:
+    """Drive a composite validation: run is_valid_errors, forward errors with
+    cursor maintenance. Composite-level errors leave the cursor untouched
+    (matches the historical behavior of attaching to the prior cursor);
+    sub-element errors switch the cursor via add_ele(map_node) before
+    forwarding."""
+    ok, errors = child_node.is_valid_errors(comp_data)
+    prev_cursor = None
+    for e in errors:
+        if e.map_node is not None and e.map_node is not prev_cursor:
+            errh.add_ele(e.map_node)
+            prev_cursor = e.map_node
+        errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
+    return ok
 
 
 ############################################################
@@ -66,14 +82,6 @@ class composite_if(x12_node):
         for e in elem.findall("element"):
             self.children.append(element_if(self.root, self, e))
 
-    def _error(self, errh: Any, err_str: str, err_cde: str, elem_val: str) -> None:
-        """
-        Forward the error to an error_handler
-        """
-        err_str2 = err_str.replace("\n", "").replace("\r", "")
-        elem_val2 = elem_val.replace("\n", "").replace("\r", "")
-        errh.ele_error(err_cde, err_str2, elem_val2, self.refdes)
-
     def debug_print(self) -> None:
         sys.stdout.write(self.__repr__())
         for node in self.children:
@@ -102,56 +110,13 @@ class composite_if(x12_node):
             sub_elem.xml()
         sys.stdout.write("</composite>\n")
 
-    def is_valid(self, comp_data: Any, errh: Any) -> bool:
-        """
-        Validates the composite
-        :param comp_data: data composite instance, has multiple values
-        :param errh: instance of error_handler
-        :rtype: boolean
-        """
-        valid = True
-        if (comp_data is None or comp_data.is_empty()) and self.usage in ("N", "S"):
-            return True
-
-        if self.usage == "R":
-            good_flag = False
-            if comp_data is not None:
-                for sub_ele in comp_data:
-                    if sub_ele is not None and len(sub_ele.get_value()) > 0:
-                        good_flag = True
-                        break
-            if not good_flag:
-                err_str = 'At least one component of composite "%s" (%s) is required' % (
-                    self.name,
-                    self.refdes,
-                )
-                errh.ele_error("2", err_str, None, self.refdes)
-                return False
-
-        if self.usage == "N" and not comp_data.is_empty():
-            err_str = 'Composite "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
-            errh.ele_error("5", err_str, None, self.refdes)
-            return False
-
-        if len(comp_data) > self.get_child_count():
-            err_str = 'Too many sub-elements in composite "%s" (%s)' % (self.name, self.refdes)
-            errh.ele_error("3", err_str, None, self.refdes)
-            valid = False
-        for i in range(min(len(comp_data), self.get_child_count())):
-            valid &= apply_element_errors(self.get_child_node_by_idx(i), comp_data[i], errh)
-        for i in range(min(len(comp_data), self.get_child_count()), self.get_child_count()):
-            if i < self.get_child_count():
-                # Check missing required elements
-                valid &= apply_element_errors(self.get_child_node_by_idx(i), None, errh)
-        return valid
-
     def is_valid_errors(self, comp_data: Any) -> tuple[bool, list[EleError]]:
         """
-        Pure validator parallel to is_valid: returns (ok, errors) without
-        touching an error handler. Composite-level errors leave map_node
-        unset (=None), so a wrapper iterating with cursor tracking will
-        attach them to whatever cursor was last set — matches the historical
-        behavior of the errh.ele_error calls in is_valid.
+        Pure validator: returns (ok, errors) without touching an error
+        handler. Composite-level errors leave map_node unset (=None) so a
+        wrapper iterating with cursor tracking attaches them to whatever
+        cursor was last set — matches the historical behavior of the
+        per-composite errh.ele_error calls.
         """
         valid = True
         errors: list[EleError] = []

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -24,7 +24,7 @@ from ..errors import EngineError
 from ..path import X12Path
 from ..syntax import is_syntax_valid
 from ._base import MAXINT, _required_attr, x12_node
-from ._composite import composite_if
+from ._composite import apply_composite_errors, composite_if
 from ._element import apply_element_errors, element_if
 
 
@@ -383,7 +383,7 @@ class segment_if(x12_node):
                     )
                     err_value = seg_data.get_value(ref_des)
                     errh.ele_error("3", err_str, err_value, ref_des)
-                valid &= child_node.is_valid(comp_data, errh)
+                valid &= apply_composite_errors(child_node, comp_data, errh)
             elif child_node.is_element():
                 # Validate Element
                 if (
@@ -406,7 +406,7 @@ class segment_if(x12_node):
             # missing required elements?
             child_node = self.get_child_node_by_idx(i)
             if child_node.is_composite():
-                valid &= child_node.is_valid(None, errh)
+                valid &= apply_composite_errors(child_node, None, errh)
             else:
                 valid &= apply_element_errors(child_node, None, errh)
 

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -369,19 +369,17 @@ class CompositeRequirement(unittest.TestCase):
         self.errh = pyx12.error_handler.errh_null()
 
     def test_comp_required_ok1(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/CLM")
         node = node.get_child_node_by_idx(4)
         self.assertNotEqual(node, None)
         # self.assertEqual(node.id, 'CLM05', node.id)
         self.assertEqual(node.base_name, "composite")
         comp = pyx12.segment.Composite("03::1", ":")
-        result = node.is_valid(comp, self.errh)
+        result, errors = node.is_valid_errors(comp)
         self.assertTrue(result)
-        self.assertEqual(self.errh.err_cde, None)
+        self.assertEqual([e.err_cde for e in errors], [])
 
     def test_comp_required_ok2(self):
-        self.errh.err_cde = None
         map = pyx12.map_if.load_map_file("comp_test.xml", self.param)
         node = map.getnodebypath("/TST")
         self.assertNotEqual(node, None)
@@ -389,12 +387,11 @@ class CompositeRequirement(unittest.TestCase):
         self.assertNotEqual(node, None)
         self.assertEqual(node.base_name, "composite")
         comp = pyx12.segment.Composite("::1", ":")
-        result = node.is_valid(comp, self.errh)
+        result, errors = node.is_valid_errors(comp)
         self.assertTrue(result)
-        self.assertEqual(self.errh.err_cde, None)
+        self.assertEqual([e.err_cde for e in errors], [])
 
     def test_comp_S_sub_R_ok3(self):
-        self.errh.err_cde = None
         map = pyx12.map_if.load_map_file("837Q3.I.5010.X223.A1.xml", self.param)
         node = map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/2400/SV2")
         node = node.get_child_node_by_idx(1)  # SV202
@@ -402,20 +399,19 @@ class CompositeRequirement(unittest.TestCase):
         self.assertEqual(node.base_name, "composite")
         # self.assertEqual(node.id, 'SV202')
         comp = pyx12.segment.Composite("", ":")
-        result = node.is_valid(comp, self.errh)
+        result, errors = node.is_valid_errors(comp)
         self.assertTrue(result)
-        self.assertEqual(self.errh.err_cde, None)
+        self.assertEqual([e.err_cde for e in errors], [])
 
     def test_comp_required_fail1(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/CLM")
         node = node.get_child_node_by_idx(4)
         self.assertNotEqual(node, None)
         self.assertEqual(node.base_name, "composite")
         comp = pyx12.segment.Composite("", ":")
-        result = node.is_valid(comp, self.errh)
+        result, errors = node.is_valid_errors(comp)
         self.assertFalse(result)
-        self.assertEqual(self.errh.err_cde, "2")
+        self.assertEqual([e.err_cde for e in errors], ["2"])
 
     def test_comp_not_used_fail1(self):
         self.errh.err_cde = None


### PR DESCRIPTION
## Summary

Phase 2 third slice. Composite validation is now driven entirely through `composite_if.is_valid_errors` + a new `apply_composite_errors` aggregator that uses cursor tracking via `EleError.map_node`. The composite wrapper, the dead `_error` shim, and the now-unused `apply_element_errors` import in `_composite.py` are gone.

- **`pyx12/map_if/_composite.py`** — new `apply_composite_errors(child_node, comp_data, errh)`. Drives `is_valid_errors` and replays `errh.add_ele(map_node)` only when the cursor changes; composite-level errors leave `map_node=None` so they attach to the prior cursor. Drop `is_valid` wrapper, dead `_error` helper, and `apply_element_errors` import.
- **`pyx12/map_if/_segment.py`** — two composite call sites in `is_valid` switch to `apply_composite_errors`. The seg-level "too many sub-elements" error continues to emit directly via `errh.ele_error`.
- **`pyx12/test/test_map_if.py`** — four composite-level tests in `CompositeRequirement` migrate from `is_valid` + `errh_null` to `is_valid_errors` + error-list assertions. Same shape as PR #149.

## Cursor behavior change

Under the old wrapper, every sub-element got an unconditional `errh.add_ele(child)` regardless of whether it produced errors. Under the new path, `add_ele(map_node)` fires only when an error is actually emitted with that cursor. This was the risk flagged in #148.

The full pytest suite (535 tests) passes — including the 997/999 ack-output tests in `test_x12n_document.py` — confirming the cursor delta is invisible to both the `err_seg.elements` consumers and the produced ack documents.

## Test plan

- [x] `pytest pyx12/test/` — 535/535 pass
- [x] `mypy --strict pyx12/` — clean
- [x] `ruff format` + `ruff check` — clean
- [ ] CI green
- [ ] `check_maps` CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)