### PR TITLE
refactor: walker accumulates errors as data; add walk_errors public API

### DIFF
--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -72,6 +72,15 @@ class ISAError(ErrorItem):
 class SegError(ErrorItem):
     err_val: str | None = None
     src_line: int | None = None
+    # Walker-supplied context for errh.add_seg(map_node, seg_data, seg_count,
+    # cur_line=src_line, ls_id) before the err_handler tree attaches the
+    # error. None means the wrapper should leave the cursor where it was
+    # (used for "usage='N'" emissions that historically attach to the prior
+    # segment cursor).
+    map_node: Any = None
+    seg_data: Any = None
+    seg_count: int | None = None
+    ls_id: str | None = None
 
     def __post_init__(self) -> None:
         if self.err_cde not in seg_errors:

--- a/pyx12/map_walker.py
+++ b/pyx12/map_walker.py
@@ -25,6 +25,7 @@ import pyx12.path
 import pyx12.segment
 
 # Intrapackage imports
+from .error_item import SegError
 from .errors import EngineError
 from .nodeCounter import NodeCounter
 
@@ -34,7 +35,7 @@ logger = logging.getLogger("pyx12.walk_tree")
 
 
 class MissingMandatorySeg(NamedTuple):
-    """A pending 'mandatory missing' error to be flushed against errh."""
+    """A pending 'mandatory missing' error to be flushed once the loop has moved on."""
 
     seg_node: Any
     seg_data: pyx12.segment.Segment
@@ -107,6 +108,24 @@ def traverse_path(start_node: Any, pop_loops: list[Any], push_loops: list[Any]) 
     return "/" + "/".join(p1)
 
 
+def apply_walk_errors(errh: Any, errors: list[SegError]) -> None:
+    """
+    Forward walker SegErrors to an err_handler. Each error with a non-None
+    map_node triggers errh.add_seg(...) before errh.seg_error(...);
+    map_node=None preserves the existing cursor (used for usage='N'
+    emissions that historically attach to the prior segment).
+
+    :param errh: Error handler
+    :type errh: L{error_handler.err_handler}
+    :param errors: SegErrors accumulated by walk_errors()
+    :type errors: [L{SegError}]
+    """
+    for e in errors:
+        if e.map_node is not None:
+            errh.add_seg(e.map_node, e.seg_data, e.seg_count, e.src_line, e.ls_id)
+        errh.seg_error(e.err_cde, e.err_str, e.err_val, e.src_line)
+
+
 class walk_tree:
     """
     Walks a map_if tree.  Tracks loop/segment counting, missing loop/segment.
@@ -114,13 +133,17 @@ class walk_tree:
 
     mandatory_segs_missing: list[MissingMandatorySeg]
     counter: NodeCounter
+    errors_pending: list[SegError]
 
     def __init__(
         self,
         initialCounts: Mapping[str | pyx12.path.X12Path, int] | None = None,
     ) -> None:
-        # Store errors until we know we have an error
+        # Pending 'mandatory missing' errors — buffered until the loop has
+        # certainly moved on, since a later segment in the same loop can
+        # still satisfy the requirement.
         self.mandatory_segs_missing = []
+        self.errors_pending = []
         if initialCounts is None:
             initialCounts = {}
         self.counter = NodeCounter(initialCounts)
@@ -134,6 +157,40 @@ class walk_tree:
         cur_line: int,
         ls_id: str | None,
     ) -> tuple[Any, list[Any], list[Any]]:
+        """
+        Backwards-compatible wrapper: drives walk_errors() and forwards the
+        produced SegErrors into the legacy err_handler API.
+
+        :param node: Starting node
+        :type node: L{node<map_if.x12_node>}
+        :param seg_data: Segment object
+        :type seg_data: L{segment<segment.Segment>}
+        :param errh: Error handler
+        :type errh: L{error_handler.err_handler}
+        :param seg_count: Count of current segment in the ST Loop
+        :type seg_count: int
+        :param cur_line: Current line number in the file
+        :type cur_line: int
+        :param ls_id: The current LS loop identifier
+        :type ls_id: string
+        :return: The matching x12 segment node, a list of x12 popped loops, and a list
+            of x12 pushed loops from the start segment to the found segment
+        :rtype: (L{node<map_if.segment_if>}, [L{node<map_if.loop_if>}], [L{node<map_if.loop_if>}])
+        """
+        result_node, pop_loops, push_loops, errors = self.walk_errors(
+            node, seg_data, seg_count, cur_line, ls_id
+        )
+        apply_walk_errors(errh, errors)
+        return result_node, pop_loops, push_loops
+
+    def walk_errors(
+        self,
+        node: Any,
+        seg_data: pyx12.segment.Segment,
+        seg_count: int,
+        cur_line: int,
+        ls_id: str | None,
+    ) -> tuple[Any, list[Any], list[Any], list[SegError]]:
         """
         Walk the node tree from the starting node to the node matching
         seg_data. Catch any counting or requirement errors along the way.
@@ -151,15 +208,17 @@ class walk_tree:
         :type cur_line: int
         :param ls_id: The current LS loop identifier
         :type ls_id: string
-        :return: The matching x12 segment node, a list of x12 popped loops, and a list
-            of x12 pushed loops from the start segment to the found segment
-        :rtype: (L{node<map_if.segment_if>}, [L{node<map_if.loop_if>}], [L{node<map_if.loop_if>}])
+        :return: The matching x12 segment node, a list of x12 popped loops,
+            a list of x12 pushed loops from the start segment to the found
+            segment, and the list of accumulated SegErrors found along the way.
+        :rtype: (L{node<map_if.segment_if>}, [L{node<map_if.loop_if>}], [L{node<map_if.loop_if>}], [L{SegError}])
 
         TODO: check single segment loop repeat
         """
         pop_node_list: list[Any] = []
         orig_node = node
         self.mandatory_segs_missing = []
+        self.errors_pending = []
         node, node_pos = walk_tree._resolve_starting_loop(node)
         while True:
             result = self._scan_loop_at_position(
@@ -167,25 +226,19 @@ class walk_tree:
                 node_pos,
                 seg_data,
                 orig_node,
-                errh,
                 seg_count,
                 cur_line,
                 ls_id,
                 pop_node_list,
             )
             if result is not None:
-                return result
+                return (*result, self.errors_pending)
             if node.is_map_root():
-                walk_tree._seg_not_found_error(
-                    orig_node, seg_data, errh, seg_count, cur_line, ls_id
-                )
-                return (None, [], [])
+                self._seg_not_found_error(orig_node, seg_data, seg_count, cur_line, ls_id)
+                return (None, [], [], self.errors_pending)
             node_pos = node.pos
             pop_node_list.append(node)
             node = pop_to_parent_loop(node)
-
-        walk_tree._seg_not_found_error(orig_node, seg_data, errh, seg_count, cur_line, ls_id)
-        return (None, [], [])
 
     def getCountState(self) -> Any:
         return self.counter.getState()
@@ -210,10 +263,11 @@ class walk_tree:
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
-        errh: Any,
     ) -> None:
         """
-        Check segment usage requirement and count
+        Check segment usage requirement and count. Any violations are
+        appended to self.errors_pending; the caller flushes them via
+        apply_walk_errors at the end of walk_errors().
 
         :param seg_node: Segment X12 node to verify
         :type seg_node: L{node<map_if.segment_if>}
@@ -225,15 +279,13 @@ class walk_tree:
         :type cur_line: int
         :param ls_id: The current LS loop identifier
         :type ls_id: string
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
         :raises EngineError: On invalid usage code
         """
         if seg_node.usage not in ("N", "R", "S"):
             raise EngineError("Segment usage must be R, S, or N (got %r)" % (seg_node.usage,))
         if seg_node.usage == "N":
             err_str = "Segment %s found but marked as not used" % (seg_node.id)
-            errh.seg_error("2", err_str, None)
+            self.errors_pending.append(SegError(err_cde="2", err_str=err_str, src_line=cur_line))
         elif seg_node.usage == "R" or seg_node.usage == "S":
             if (
                 self.counter.get_count(seg_node.x12path) > seg_node.get_max_repeat()
@@ -243,8 +295,17 @@ class walk_tree:
                     self.counter.get_count(seg_node.x12path),
                     seg_node.get_max_repeat(),
                 )
-                errh.add_seg(seg_node, seg_data, seg_count, cur_line, ls_id)
-                errh.seg_error("5", err_str, None)
+                self.errors_pending.append(
+                    SegError(
+                        err_cde="5",
+                        err_str=err_str,
+                        src_line=cur_line,
+                        map_node=seg_node,
+                        seg_data=seg_data,
+                        seg_count=seg_count,
+                        ls_id=ls_id,
+                    )
+                )
 
     def _try_match_segment_child(
         self,
@@ -252,7 +313,6 @@ class walk_tree:
         child: Any,
         seg_data: pyx12.segment.Segment,
         orig_node: Any,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
@@ -272,26 +332,23 @@ class walk_tree:
         """
         if child.is_match(seg_data):
             # Is the matched segment the beginning of a loop?
-            if node.is_loop() and self._is_loop_match(
-                node, seg_data, errh, seg_count, cur_line, ls_id
-            ):
+            if node.is_loop() and self._is_loop_match(node, seg_data, seg_count, cur_line, ls_id):
                 return self._match_segment_at_loop_entry(
                     node,
                     seg_data,
                     orig_node,
-                    errh,
                     seg_count,
                     cur_line,
                     ls_id,
                     pop_node_list,
                 )
             self.counter.increment(child.x12path)
-            self._check_seg_usage(child, seg_data, seg_count, cur_line, ls_id, errh)
+            self._check_seg_usage(child, seg_data, seg_count, cur_line, ls_id)
             # Remove any previously missing errors for this segment
             self.mandatory_segs_missing = [
                 m for m in self.mandatory_segs_missing if m.seg_node != child
             ]
-            self._flush_mandatory_segs(errh, child.pos)
+            self._flush_mandatory_segs(child.pos)
             return (child, pop_node_list, [])
         if child.usage == "R" and self.counter.get_count(child.x12path) < 1:
             fake_seg = pyx12.segment.Segment("%s" % (child.id), "~", "*", ":")
@@ -306,7 +363,6 @@ class walk_tree:
         node: Any,
         seg_data: pyx12.segment.Segment,
         orig_node: Any,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
@@ -320,7 +376,7 @@ class walk_tree:
         signalling "we re-entered the same loop we started in".
         """
         (node_seg, push_node_list) = self._goto_seg_match(
-            node, seg_data, errh, seg_count, cur_line, ls_id
+            node, seg_data, seg_count, cur_line, ls_id
         )
         orig_loop = (
             orig_node
@@ -335,7 +391,6 @@ class walk_tree:
         self,
         child: Any,
         seg_data: pyx12.segment.Segment,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
@@ -349,10 +404,10 @@ class walk_tree:
         push list is the chain of loops entered to reach the segment.
         On no match, returns None.
         """
-        if not self._is_loop_match(child, seg_data, errh, seg_count, cur_line, ls_id):
+        if not self._is_loop_match(child, seg_data, seg_count, cur_line, ls_id):
             return None
         (node_seg, push_node_list) = self._goto_seg_match(
-            child, seg_data, errh, seg_count, cur_line, ls_id
+            child, seg_data, seg_count, cur_line, ls_id
         )
         return (node_seg, pop_node_list, push_node_list)
 
@@ -362,7 +417,6 @@ class walk_tree:
         node_pos: int,
         seg_data: pyx12.segment.Segment,
         orig_node: Any,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
@@ -382,7 +436,6 @@ class walk_tree:
                         child,
                         seg_data,
                         orig_node,
-                        errh,
                         seg_count,
                         cur_line,
                         ls_id,
@@ -394,7 +447,6 @@ class walk_tree:
                     result = self._try_match_loop_child(
                         child,
                         seg_data,
-                        errh,
                         seg_count,
                         cur_line,
                         ls_id,
@@ -416,45 +468,71 @@ class walk_tree:
             node = pop_to_parent_loop(node)
         return node, node_pos
 
-    @staticmethod
     def _seg_not_found_error(
+        self,
         orig_node: Any,
         seg_data: pyx12.segment.Segment,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
     ) -> None:
         """
-        Create error for not found segments
+        Accumulate a 'segment not found' error onto self.errors_pending.
 
         :param orig_node: Original starting node
         :type orig_node: L{node<map_if.x12_node>}
         :param seg_data: Segment object
         :type seg_data: L{segment<segment.Segment>}
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
+        :param seg_count: Count of current segment in the ST Loop
+        :type seg_count: int
+        :param cur_line: Current line number in the file
+        :type cur_line: int
+        :param ls_id: The current LS loop identifier
+        :type ls_id: string
         """
         if seg_data.get_seg_id() == "HL":
             seg_str = seg_data.format("", "*", ":")
         else:
             seg_str = "%s*%s" % (seg_data.get_seg_id(), seg_data.get_value("01"))
         err_str = "Segment %s not found.  Started at %s" % (seg_str, orig_node.get_path())
-        errh.add_seg(orig_node, seg_data, seg_count, cur_line, ls_id)
-        errh.seg_error("1", err_str, None)
+        self.errors_pending.append(
+            SegError(
+                err_cde="1",
+                err_str=err_str,
+                src_line=cur_line,
+                map_node=orig_node,
+                seg_data=seg_data,
+                seg_count=seg_count,
+                ls_id=ls_id,
+            )
+        )
 
-    def _flush_mandatory_segs(self, errh: Any, cur_pos: int | None = None) -> None:
+    def _flush_mandatory_segs(self, cur_pos: int | None = None) -> None:
         """
-        Handle error reporting for any outstanding missing mandatory segments
+        Move any outstanding mandatory-missing errors out of
+        self.mandatory_segs_missing into self.errors_pending — except
+        those whose seg_node.pos matches cur_pos (those can still be
+        satisfied at the current position).
 
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
+        :param cur_pos: Current segment position; entries at this
+            position are kept in the buffer for possible later
+            satisfaction.
+        :type cur_pos: int or None
         """
         for m in self.mandatory_segs_missing:
             # Create errors if not also at current position
             if m.seg_node.pos != cur_pos:
-                errh.add_seg(m.seg_node, m.seg_data, m.seg_count, m.cur_line, m.ls_id)
-                errh.seg_error(m.err_cde, m.err_str, None)
+                self.errors_pending.append(
+                    SegError(
+                        err_cde=m.err_cde,
+                        err_str=m.err_str,
+                        src_line=m.cur_line,
+                        map_node=m.seg_node,
+                        seg_data=m.seg_data,
+                        seg_count=m.seg_count,
+                        ls_id=m.ls_id,
+                    )
+                )
         self.mandatory_segs_missing = [
             m for m in self.mandatory_segs_missing if m.seg_node.pos == cur_pos
         ]
@@ -486,22 +564,25 @@ class walk_tree:
         self,
         loop_node: Any,
         seg_data: pyx12.segment.Segment,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
     ) -> bool:
         """
-        Try to match the current loop to the segment
+        Try to match the current loop to the segment.
         Handle loop and segment counting.
-        Check for used/missing
+        Check for used/missing.
 
         :param loop_node: Loop Node
         :type loop_node: L{node<map_if.loop_if>}
         :param seg_data: Segment object
         :type seg_data: L{segment<segment.Segment>}
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
+        :param seg_count: Count of current segment in the ST Loop
+        :type seg_count: int
+        :param cur_line: Current line number in the file
+        :type cur_line: int
+        :param ls_id: The current LS loop identifier
+        :type ls_id: string
 
         :return: Does the segment match the first segment node in the loop?
         :rtype: boolean
@@ -519,8 +600,7 @@ class walk_tree:
         if first_child_node.is_loop():
             # Wrapper loop: match if any direct child loop matches.
             return any(
-                child.is_loop()
-                and self._is_loop_match(child, seg_data, errh, seg_count, cur_line, ls_id)
+                child.is_loop() and self._is_loop_match(child, seg_data, seg_count, cur_line, ls_id)
                 for child in loop_node.childIterator()
             )
         if is_first_seg_match2(first_child_node, seg_data):
@@ -538,7 +618,6 @@ class walk_tree:
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
-        errh: Any,
     ) -> tuple[Any, list[Any]]:
         """
         Record entering loop_node via its first segment: check loop usage
@@ -546,16 +625,15 @@ class walk_tree:
         any pending mandatory-missing errors. Returns the matched segment
         and the single-element push list [loop_node].
         """
-        self._check_loop_usage(loop_node, seg_data, seg_count, cur_line, ls_id, errh)
+        self._check_loop_usage(loop_node, seg_data, seg_count, cur_line, ls_id)
         self.counter.increment(first_seg.x12path)
-        self._flush_mandatory_segs(errh)
+        self._flush_mandatory_segs()
         return (first_seg, [loop_node])
 
     def _goto_seg_match(
         self,
         loop_node: Any,
         seg_data: pyx12.segment.Segment,
-        errh: Any,
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
@@ -568,12 +646,11 @@ class walk_tree:
         :type loop_node: L{node<map_if.loop_if>}
         :param seg_data: Segment object
         :type seg_data: L{segment<segment.Segment>}
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
         :param seg_count: Current segment count for ST loop
         :type seg_count: int
         :param cur_line: File line counter
         :type cur_line: int
+        :param ls_id: The current LS loop identifier
         :type ls_id: string
 
         :return: The matching segment node and a list of the push loop nodes
@@ -587,12 +664,12 @@ class walk_tree:
         first_seg = loop_node.get_first_seg()
         if first_seg is not None and is_first_seg_match2(first_seg, seg_data):
             return self._enter_loop_at_first_seg(
-                loop_node, first_seg, seg_data, seg_count, cur_line, ls_id, errh
+                loop_node, first_seg, seg_data, seg_count, cur_line, ls_id
             )
         for child in loop_node.childIterator():
             if not child.is_loop():
                 continue
-            seg_node, push = self._goto_seg_match(child, seg_data, errh, seg_count, cur_line, ls_id)
+            seg_node, push = self._goto_seg_match(child, seg_data, seg_count, cur_line, ls_id)
             if seg_node is not None:
                 return (seg_node, [loop_node, *push])
         return (None, [])
@@ -604,10 +681,11 @@ class walk_tree:
         seg_count: int,
         cur_line: int,
         ls_id: str | None,
-        errh: Any,
     ) -> None:
         """
-        Check loop usage requirement and count
+        Check loop usage requirement and count. Any violations are
+        appended to self.errors_pending; the caller flushes them via
+        apply_walk_errors at the end of walk_errors().
 
         :param loop_node: Loop X12 node to verify
         :type loop_node: L{node<map_if.loop_if>}
@@ -619,8 +697,6 @@ class walk_tree:
         :type cur_line: int
         :param ls_id: The current LS loop identifier
         :type ls_id: string
-        :param errh: Error handler
-        :type errh: L{error_handler.err_handler}
         :raises EngineError: On invalid usage code
         """
         if not loop_node.is_loop():
@@ -631,7 +707,7 @@ class walk_tree:
             raise EngineError("Loop usage must be R, S, or N (got %r)" % (loop_node.usage,))
         if loop_node.usage == "N":
             err_str = "Loop %s found but marked as not used" % (loop_node.id)
-            errh.seg_error("2", err_str, None)
+            self.errors_pending.append(SegError(err_cde="2", err_str=err_str, src_line=cur_line))
         elif loop_node.usage in ("R", "S"):
             self.counter.reset_to_node(loop_node.x12path)
             self.counter.increment(loop_node.x12path)
@@ -641,5 +717,14 @@ class walk_tree:
                     self.counter.get_count(loop_node.x12path),
                     loop_node.get_max_repeat(),
                 )
-                errh.add_seg(loop_node, seg_data, seg_count, cur_line, ls_id)
-                errh.seg_error("4", err_str, None)
+                self.errors_pending.append(
+                    SegError(
+                        err_cde="4",
+                        err_str=err_str,
+                        src_line=cur_line,
+                        map_node=loop_node,
+                        seg_data=seg_data,
+                        seg_count=seg_count,
+                        ls_id=ls_id,
+                    )
+                )

--- a/pyx12/test/test_map_walker.py
+++ b/pyx12/test/test_map_walker.py
@@ -841,7 +841,6 @@ class TryMatchSegmentChild(unittest.TestCase):
 
     def test_match_simple_segment(self):
         """Non-first child segment in its loop -> plain match, push empty."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/IEA")
         orig_node = child
@@ -850,25 +849,24 @@ class TryMatchSegmentChild(unittest.TestCase):
         self.walker.setCountState({loop_node.x12path: 1})
         seg_data = pyx12.segment.Segment("IEA*1*000000123", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, orig_node, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, orig_node, 5, 4, None, []
         )
         self.assertIsNotNone(result)
         node, pop, push = result
         self.assertEqual(node.id, "IEA")
         self.assertEqual(get_id_list(pop), [])
         self.assertEqual(get_id_list(push), [])
-        self.assertEqual(self.errh.err_cde, None, self.errh.err_str)
+        self.assertEqual(self.walker.errors_pending, [])
 
     def test_match_loop_entry_pushes_loop(self):
         """First segment of loop_node -> loop-entry path pushes [loop_node]."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/GS")
         # orig_node sits outside GS_LOOP so the orig_loop == node branch is NOT taken.
         orig_node = self.map.getnodebypath("/ISA_LOOP/ISA")
         seg_data = pyx12.segment.Segment("GS*HC*A*B*20080101*1010*1*X*004010X098A1", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, orig_node, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, orig_node, 5, 4, None, []
         )
         self.assertIsNotNone(result)
         node, pop, push = result
@@ -878,14 +876,13 @@ class TryMatchSegmentChild(unittest.TestCase):
 
     def test_match_loop_entry_when_orig_loop_equals_node(self):
         """orig_node pops up to loop_node -> pop and push both become [loop_node]."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/GS")
         # Sibling segment within GS_LOOP -> pop_to_parent_loop -> GS_LOOP == loop_node.
         orig_node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/GE")
         seg_data = pyx12.segment.Segment("GS*HC*A*B*20080101*1010*1*X*004010X098A1", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, orig_node, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, orig_node, 5, 4, None, []
         )
         self.assertIsNotNone(result)
         node, pop, push = result
@@ -895,7 +892,6 @@ class TryMatchSegmentChild(unittest.TestCase):
 
     def test_match_clears_prior_missing_for_same_child(self):
         """Simple match removes any earlier accumulated missing-error entry for child."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/IEA")
         # Seed a stale missing entry for this same child node.
@@ -912,7 +908,7 @@ class TryMatchSegmentChild(unittest.TestCase):
         )
         seg_data = pyx12.segment.Segment("IEA*1*000000123", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, child, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, child, 5, 4, None, []
         )
         self.assertIsNotNone(result)
         self.assertEqual([m for m in self.walker.mandatory_segs_missing if m.seg_node == child], [])
@@ -921,13 +917,12 @@ class TryMatchSegmentChild(unittest.TestCase):
 
     def test_no_match_required_uncounted_accumulates_missing(self):
         """Required (R) uncounted child + non-matching seg -> None, missing recorded."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/IEA")
         self.assertEqual(child.usage, "R")
         seg_data = pyx12.segment.Segment("ZZZ*1", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, child, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, child, 5, 4, None, []
         )
         self.assertIsNone(result)
         self.assertEqual(len(self.walker.mandatory_segs_missing), 1)
@@ -936,13 +931,12 @@ class TryMatchSegmentChild(unittest.TestCase):
 
     def test_no_match_required_already_counted_no_accumulation(self):
         """Required child with count >= 1 + non-matching seg -> None, no accumulation."""
-        self.errh.reset()
         loop_node = self.map.getnodebypath("/ISA_LOOP")
         child = self.map.getnodebypath("/ISA_LOOP/IEA")
         self.walker.setCountState({child.x12path: 1})
         seg_data = pyx12.segment.Segment("ZZZ*1", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, child, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, child, 5, 4, None, []
         )
         self.assertIsNone(result)
         self.assertEqual(self.walker.mandatory_segs_missing, [])
@@ -950,22 +944,20 @@ class TryMatchSegmentChild(unittest.TestCase):
     # ---- expected errors ----
 
     def test_match_unused_segment_emits_error_2(self):
-        """Match on a usage='N' segment -> err_cde '2' on errh."""
-        self.errh.reset()
+        """Match on a usage='N' segment -> err_cde '2' accumulated."""
         cmap = pyx12.map_if.load_map_file("comp_test.xml", self.param)
         child = cmap.getnodebypath("/UNU")
         self.assertEqual(child.usage, "N")
         loop_node = child.parent
         seg_data = pyx12.segment.Segment("UNU*AA*B", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, child, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, child, 5, 4, None, []
         )
         self.assertIsNotNone(result)
-        self.assertEqual(self.errh.err_cde, "2", self.errh.err_str)
+        self.assertEqual([e.err_cde for e in self.walker.errors_pending], ["2"])
 
     def test_match_exceeds_max_count_emits_error_5(self):
-        """Increment past max_repeat on R/S match -> err_cde '5' on errh."""
-        self.errh.reset()
+        """Increment past max_repeat on R/S match -> err_cde '5' accumulated."""
         cmap = pyx12.map_if.load_map_file("270.4010.X092.A1.xml", self.param)
         loop_node = cmap.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2100B")
         child = cmap.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2100B/PER")
@@ -977,10 +969,10 @@ class TryMatchSegmentChild(unittest.TestCase):
         )
         seg_data = pyx12.segment.Segment("PER*IC*Name1*EM*dev@null.com", "~", "*", ":")
         result = self.walker._try_match_segment_child(
-            loop_node, child, seg_data, child, self.errh, 5, 4, None, []
+            loop_node, child, seg_data, child, 5, 4, None, []
         )
         self.assertIsNotNone(result)
-        self.assertEqual(self.errh.err_cde, "5", self.errh.err_str)
+        self.assertEqual([e.err_cde for e in self.walker.errors_pending], ["5"])
 
 
 class TryMatchLoopChild(unittest.TestCase):
@@ -1012,10 +1004,9 @@ class TryMatchLoopChild(unittest.TestCase):
 
     def test_match_shallow_loop(self):
         """child is a loop; seg_data matches its first segment -> push=[loop]."""
-        self.errh.reset()
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         seg_data = pyx12.segment.Segment("GS*HC*A*B*20080101*1010*1*X*004010X098A1", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, [])
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, [])
         self.assertIsNotNone(result)
         node, pop, push = result
         self.assertEqual(node.id, "GS")
@@ -1024,11 +1015,10 @@ class TryMatchLoopChild(unittest.TestCase):
 
     def test_match_nested_loop(self):
         """child is a loop whose first child is a loop -> nested descent."""
-        self.errh.reset()
         # DETAIL's first child is 2000A (a loop). 2000A's first segment is HL.
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL")
         seg_data = pyx12.segment.Segment("HL*1**20*1", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, [])
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, [])
         self.assertIsNotNone(result)
         node, pop, push = result
         self.assertEqual(node.id, "HL")
@@ -1040,12 +1030,11 @@ class TryMatchLoopChild(unittest.TestCase):
 
     def test_no_match_required_uncounted_accumulates_missing(self):
         """Required loop with count 0 + non-matching seg -> None, missing recorded."""
-        self.errh.reset()
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         first_child = child.get_first_node()  # = GS segment
         self.assertEqual(child.usage, "R")
         seg_data = pyx12.segment.Segment("ZZZ*1", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, [])
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, [])
         self.assertIsNone(result)
         self.assertEqual(len(self.walker.mandatory_segs_missing), 1)
         # The accumulated entry references the loop's first child, not the loop itself.
@@ -1054,11 +1043,10 @@ class TryMatchLoopChild(unittest.TestCase):
 
     def test_no_match_required_counted_no_accumulation(self):
         """Required loop with count >= 1 + non-matching seg -> None, no accumulation."""
-        self.errh.reset()
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         self.walker.setCountState({child.x12path: 1})
         seg_data = pyx12.segment.Segment("ZZZ*1", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, [])
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, [])
         self.assertIsNone(result)
         self.assertEqual(self.walker.mandatory_segs_missing, [])
 
@@ -1066,24 +1054,22 @@ class TryMatchLoopChild(unittest.TestCase):
 
     def test_match_exceeds_max_loop_count_emits_error_4(self):
         """Match that pushes loop count past max_repeat -> err_cde '4'."""
-        self.errh.reset()
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/2400")
         self.walker.setCountState({child.x12path: 50})
         seg_data = pyx12.segment.Segment("LX*51", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, [])
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, [])
         self.assertIsNotNone(result)
-        self.assertEqual(self.errh.err_cde, "4", self.errh.err_str)
+        self.assertEqual([e.err_cde for e in self.walker.errors_pending], ["4"])
 
     # ---- pop list pass-through ----
 
     def test_pop_list_passed_through_on_match(self):
         """The helper returns the same pop list it received (by reference)."""
-        self.errh.reset()
         child = self.map.getnodebypath("/ISA_LOOP/GS_LOOP")
         sentinel_loop = self.map.getnodebypath("/ISA_LOOP")
         pop_in: list[object] = [sentinel_loop]
         seg_data = pyx12.segment.Segment("GS*HC*A*B*20080101*1010*1*X*004010X098A1", "~", "*", ":")
-        result = self.walker._try_match_loop_child(child, seg_data, self.errh, 5, 4, None, pop_in)
+        result = self.walker._try_match_loop_child(child, seg_data, 5, 4, None, pop_in)
         self.assertIsNotNone(result)
         assert result is not None  # narrow for type checker
         self.assertIs(result[1], pop_in)


### PR DESCRIPTION
## Summary

Phase 3 first slice. Refactor `map_walker.py` internals so every helper that previously emitted errors via `errh.seg_error` / `errh.add_seg` now appends a `SegError` to `self.errors_pending`. The public `walk(...)` method becomes a thin wrapper that drives the new `walk_errors(...)` and forwards accumulated errors via `apply_walk_errors`. **No production caller's signature changes** — `x12n_document`, `x12context`, `x12metadata`, and the example scripts continue to call `walk(...)` unchanged.

## Changes

- **`pyx12/error_item.py`** — `SegError` gains four optional walker-context fields (`map_node`, `seg_data`, `seg_count`, `ls_id`) defaulting to `None`. A non-`None` `map_node` tells the wrapper to call `errh.add_seg(...)` before `errh.seg_error(...)`; `None` preserves the existing cursor (used for `usage='N'` emissions that historically attach to the prior segment).
- **`pyx12/map_walker.py`**:
  - New top-level `apply_walk_errors(errh, errors)` — the bridge from the pure errors-as-data surface back to `err_handler`.
  - New `walk_errors(node, seg_data, seg_count, cur_line, ls_id) -> (node, pop, push, list[SegError])` public method.
  - `walk(...)` is a backwards-compatible wrapper that drives `walk_errors` and applies via `apply_walk_errors`.
  - Eleven `errh.seg_error` / `errh.add_seg` call sites converted to `SegError(...)` appends.
  - All internal helpers drop `errh` from their signatures; Sphinx `:param`/`:type`/`:return` blocks preserved with the `errh` entries removed.
- **`pyx12/test/test_map_walker.py`** — 14 direct-helper test sites in `TryMatchSegmentChild` / `TryMatchLoopChild` migrate from passing `self.errh` into the helpers and asserting on `self.errh.err_cde`, to calling without `errh` and asserting on `self.walker.errors_pending`. Integration tests calling `walker.walk(...)` end-to-end stay unchanged.

## Why a wrapper

Walker has many production callers (`x12n_document`, `X12ContextReader`, `x12metadata`, several `examples/`, the test suite). Switching them all in one PR would balloon scope. This slice proves the internal refactor with no caller-visible change. The next slice migrates callers to `walk_errors` directly and deletes the wrapper.

## Test plan

- [x] `pytest pyx12/test/` — 535/535 pass
- [x] `mypy --strict pyx12/` — clean
- [x] `ruff format` + `ruff check` — clean
- [ ] CI green
- [ ] `check_maps` CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)