### PR TITLE
chore: drop dead errh_null stubs from tests

### DIFF
--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pyx12.error_handler
 import pyx12.map_if
 import pyx12.params
 import pyx12.path
@@ -353,7 +352,6 @@ class CompositeRequirement(unittest.TestCase):
     def setUp(self):
         self.param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("837.4010.X098.A1.xml", self.param)
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_comp_required_ok1(self):
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/CLM")
@@ -455,7 +453,6 @@ class ElementRequirement(unittest.TestCase):
     def setUp(self):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("837.4010.X098.A1.xml", param)
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_ele_not_used_fail1(self):
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/HEADER/REF")
@@ -484,10 +481,8 @@ class NodeEquality(unittest.TestCase):
     def setUp(self):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("837.4010.X098.A1.xml", param)
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_eq_1(self):
-        self.errh.err_cde = None
         node1 = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300")
         self.assertNotEqual(node1, None)
         node2 = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300")
@@ -495,7 +490,6 @@ class NodeEquality(unittest.TestCase):
         self.assertTrue(node1 == node2)
 
     def test_neq_1(self):
-        self.errh.err_cde = None
         node1 = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300")
         self.assertNotEqual(node1, None)
         node2 = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/2400")
@@ -508,10 +502,8 @@ class LoopIsMatch(unittest.TestCase):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("837Q3.I.5010.X223.A1.xml", param)
         self.node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300")
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_match_self(self):
-        self.errh.err_cde = None
         seg_data = pyx12.segment.Segment("CLM*657657*AA**5::1~", "~", "*", ":")
         self.assertTrue(self.node.is_match(seg_data))
 
@@ -524,10 +516,8 @@ class GetNodeBySegment(unittest.TestCase):
     def setUp(self):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("834.5010.X220.A1.xml", param)
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_get_seg_node(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "2000")
@@ -541,7 +531,6 @@ class GetNodeBySegment(unittest.TestCase):
         self.assertEqual(seg_node.id, "INS")
 
     def test_get_loop_node(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "2000")
@@ -551,7 +540,6 @@ class GetNodeBySegment(unittest.TestCase):
         self.assertEqual(loop_node.id, "2100A")
 
     def test_get_seg_node_fail(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "2000")
@@ -560,7 +548,6 @@ class GetNodeBySegment(unittest.TestCase):
         self.assertEqual(seg_node, None)
 
     def test_get_loop_node_fail(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "2000")
@@ -574,10 +561,8 @@ class MatchSegmentQual(unittest.TestCase):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("837Q3.I.5010.X223.A1.xml", param)
         self.node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300")
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_match_plain_ok1(self):
-        self.errh.err_cde = None
         node = self.node.getnodebypath("CLM")
         seg_data = pyx12.segment.Segment("CLM*Y", "~", "*", ":")
         (is_match, qual_code, matched_ele_idx, matched_subele_idx) = node.is_match_qual(
@@ -586,7 +571,6 @@ class MatchSegmentQual(unittest.TestCase):
         self.assertTrue(is_match)
 
     def test_match_qual_ok1(self):
-        self.errh.err_cde = None
         node = self.node.getnodebypath("DTP[435]")
         seg_data = pyx12.segment.Segment("DTP*435*D8*20090101~", "~", "*", ":")
         (is_match, qual_code, matched_ele_idx, matched_subele_idx) = node.is_match_qual(
@@ -595,7 +579,6 @@ class MatchSegmentQual(unittest.TestCase):
         self.assertTrue(is_match)
 
     def test_match_qual_ok2(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2010AA/REF")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "REF")
@@ -696,16 +679,13 @@ class GetCompositeNodeByPath(unittest.TestCase):
     def setUp(self):
         param = pyx12.params.params()
         self.map = pyx12.map_if.load_map_file("277.5010.X214.xml", param)
-        self.errh = pyx12.error_handler.errh_null()
 
     def test_get_segment_node_absolute(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC02")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "STC02")
 
     def test_get_composite_node_absolute(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2(
             "/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC01-01"
         )
@@ -713,7 +693,6 @@ class GetCompositeNodeByPath(unittest.TestCase):
         self.assertEqual(node.id, "STC01-01")
 
     def test_get_segment_node_relative(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "2200B")
@@ -722,13 +701,11 @@ class GetCompositeNodeByPath(unittest.TestCase):
         self.assertEqual(node2.id, "STC02")
 
     def test_get_composite_node(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC02")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "STC02")
 
     def test_get_node_path_refdes(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC02")
         self.assertNotEqual(node, None)
         self.assertEqual(node.id, "STC02")
@@ -739,7 +716,6 @@ class GetCompositeNodeByPath(unittest.TestCase):
         )
 
     def test_get_composite_node_path_refdes(self):
-        self.errh.err_cde = None
         node = self.map.getnodebypath2(
             "/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2200B/STC01-01"
         )

--- a/pyx12/test/test_map_unique.py
+++ b/pyx12/test/test_map_unique.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pyx12.error_handler
 import pyx12.map_if
 import pyx12.params
 
@@ -8,10 +7,8 @@ import pyx12.params
 class UniqueNodePath(unittest.TestCase):
     def setUp(self):
         self.param = pyx12.params.params()
-        self.errh = pyx12.error_handler.errh_null()
 
     def _get_paths(self, map_file):
-        self.errh.reset()
         paths = set()
         map1 = pyx12.map_if.load_map_file(map_file, self.param)
         for x in [a for a in map1.loop_segment_iterator() if a.is_loop()]:
@@ -21,7 +18,6 @@ class UniqueNodePath(unittest.TestCase):
         return paths
 
     def test_all_unique(self):
-        self.errh.reset()
         paths = set()
         map1 = pyx12.map_if.load_map_file("837.4010.X098.A1.xml", self.param)
         for x in map1.loop_segment_iterator():

--- a/pyx12/test/test_x12file.py
+++ b/pyx12/test/test_x12file.py
@@ -370,7 +370,6 @@ class Segment_ID_Checks(X12fileTestCase):
         self.assertEqual(err_cde, "1", err_str)
 
     def test_segment_empty(self):
-        errh = pyx12.error_handler.errh_null()
         str1 = "ISA*00*          *00*          *ZZ*ZZ000          *ZZ*ZZ001          *030828*1128*U*00401*000010121*0*T*:~\n"
         str1 += "TST~\n"
         (err_cde, err_str) = self._get_first_error(str1)


### PR DESCRIPTION
## Summary

Phase 4 cleanup. The producer-side refactor (PRs #147–#153) removed `errh` from validator and walker test paths, but the `setUp` methods that created an `errh_null` sink were left behind, along with stale `self.errh.err_cde = None` / `self.errh.reset()` lines that no longer have any effect. This PR sweeps the residue.

## What stays

- **`errh_null`** — kept as the test sink for orchestrator tests (`test_x12n_document`, `test_x12context`, `test_x12file`, `test_map_walker` integration) and example scripts, where the `err_handler` is genuinely threaded through.
- **`errh_list`** — kept; it's a documented public API still used by `X12ContextReader`.

The original Phase 4 plan goal of "retire `errh_null` entirely" isn't achievable post-refactor because orchestrators still take `errh`. This PR limits Phase 4 to dropping the dead test stubs.

## Changes

- **`pyx12/test/test_map_if.py`** — drop unused `import pyx12.error_handler`. Drop dead `self.errh = errh_null()` setUps in `CompositeRequirement`, `ElementRequirement`, `NodeEquality`, `LoopIsMatch`, `GetNodeBySegment`, `MatchSegmentQual`, `GetCompositeNodeByPath`. Drop ~13 stale `self.errh.err_cde = None` lines.
- **`pyx12/test/test_map_unique.py`** — drop dead `self.errh` setUp and two `self.errh.reset()` calls.
- **`pyx12/test/test_x12file.py`** — drop one dead local `errh` in `test_segment_empty`.

Net 29 deletions. No test logic changed.

## Test plan

- [x] `pytest pyx12/test/` — 535/535 pass
- [x] `mypy --strict pyx12/` — clean
- [x] `ruff format` + `ruff check` — clean
- [ ] CI green
- [ ] `check_maps` CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)