### PR TITLE
refactor: tighten mypy typing in pyx12/map_if/; drop ~50 Any annotations

### DIFF
--- a/pyx12/map_if/_base.py
+++ b/pyx12/map_if/_base.py
@@ -12,7 +12,6 @@ Base node and shared helpers for the X12N IG map interface.
 
 from __future__ import annotations
 
-from typing import Any
 from xml.etree.ElementTree import Element
 
 from ..errors import EngineError
@@ -35,8 +34,9 @@ class x12_node:
 
     id: str | None
     name: str | None
-    parent: Any
-    children: list[Any]
+    usage: str | None
+    parent: x12_node | None
+    children: list[x12_node]
     path: str
     _x12path: X12Path | None
     _fullpath: str | None
@@ -44,6 +44,7 @@ class x12_node:
     def __init__(self) -> None:
         self.id = None
         self.name = None
+        self.usage = None
         self.parent = None
         self.children = []
         self.path = ""
@@ -52,6 +53,7 @@ class x12_node:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, x12_node):
+            assert self.parent is not None and other.parent is not None
             return self.id == other.id and self.parent.id == other.parent.id
         return NotImplemented
 
@@ -64,6 +66,7 @@ class x12_node:
     __ge__ = __lt__
 
     def __hash__(self) -> int:
+        assert self.parent is not None
         return ((self.id or "") + (self.parent.id or "")).__hash__()
 
     def __len__(self) -> int:
@@ -75,12 +78,13 @@ class x12_node:
         """
         return self.name or ""
 
-    def getnodebypath(self, path: str) -> Any:
+    def getnodebypath(self, path: str) -> x12_node | None:
         """ """
         pathl = path.split("/")
         if len(pathl) == 0:
             return None
         for child in self.children:
+            assert child.id is not None
             if child.id.lower() == pathl[0].lower():
                 if len(pathl) == 1:
                     return child
@@ -94,7 +98,7 @@ class x12_node:
     def get_child_count(self) -> int:
         return len(self.children)
 
-    def get_child_node_by_idx(self, idx: int) -> Any:
+    def get_child_node_by_idx(self, idx: int) -> x12_node | None:
         """
         :param idx: zero based
         """
@@ -103,7 +107,7 @@ class x12_node:
         else:
             return self.children[idx]
 
-    def get_child_node_by_ordinal(self, ordinal: int) -> Any:
+    def get_child_node_by_ordinal(self, ordinal: int) -> x12_node | None:
         """
         Get a child element or composite by the X12 ordinal
         :param ord: one based element/composite index.  Corresponds to the map <seq> element
@@ -118,6 +122,7 @@ class x12_node:
         """
         if self._fullpath:
             return self._fullpath
+        assert self.parent is not None
         parent_path = self.parent.get_path()
         if parent_path == "/":
             self._fullpath = "/" + self.path
@@ -138,6 +143,14 @@ class x12_node:
         return p
 
     x12path = property(_get_x12_path, None, None)
+
+    def debug_print(self) -> None:
+        """ """
+        pass
+
+    def xml(self) -> None:
+        """ """
+        pass
 
     def is_first_seg_in_loop(self) -> bool:
         """
@@ -174,7 +187,3 @@ class x12_node:
         :rtype: boolean
         """
         return False
-
-
-############################################################
-# Map file interface

--- a/pyx12/map_if/_composite.py
+++ b/pyx12/map_if/_composite.py
@@ -13,12 +13,17 @@ Composite interface - sub-element container.
 from __future__ import annotations
 
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 from xml.etree.ElementTree import Element
+
+import pyx12.segment
 
 from ..error_item import EleError
 from ._base import _required_attr, x12_node
 from ._element import element_if
+
+if TYPE_CHECKING:
+    from ._root import map_if
 
 
 ############################################################
@@ -29,15 +34,15 @@ class composite_if(x12_node):
     Composite Node Interface
     """
 
-    root: Any
+    root: map_if
+    children: list[element_if]  # type: ignore[assignment]
     base_name: str
     refdes: str | None
     data_ele: str | None
-    usage: str | None
     seq: int
     repeat: int
 
-    def __init__(self, root: Any, parent: Any, elem: Element) -> None:
+    def __init__(self, root: map_if, parent: x12_node, elem: Element) -> None:
         """
         Get the values for this composite
         :param parent: parent node
@@ -94,7 +99,9 @@ class composite_if(x12_node):
             sub_elem.xml()
         sys.stdout.write("</composite>\n")
 
-    def is_valid_errors(self, comp_data: Any) -> tuple[bool, list[EleError]]:
+    def is_valid_errors(
+        self, comp_data: pyx12.segment.Composite | None
+    ) -> tuple[bool, list[EleError]]:
         """
         Pure validator: returns (ok, errors) without touching an error
         handler. Composite-level errors leave map_node unset (=None) so a
@@ -111,7 +118,8 @@ class composite_if(x12_node):
         if self.usage == "R":
             good_flag = False
             if comp_data is not None:
-                for sub_ele in comp_data:
+                for j in range(len(comp_data)):
+                    sub_ele = comp_data[j]
                     if sub_ele is not None and len(sub_ele.get_value()) > 0:
                         good_flag = True
                         break
@@ -122,6 +130,10 @@ class composite_if(x12_node):
                 )
                 return False, [EleError(err_cde="1", err_str=err_str, refdes=self.refdes)]
 
+        # Past here, comp_data is non-None: the (None or empty)+(N/S) branch
+        # short-circuited it; the R branch returned on missing comp_data.
+        assert comp_data is not None
+
         if self.usage == "N" and not comp_data.is_empty():
             err_str = 'Composite "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
             return False, [EleError(err_cde="5", err_str=err_str, refdes=self.refdes)]
@@ -131,12 +143,12 @@ class composite_if(x12_node):
             errors.append(EleError(err_cde="3", err_str=err_str, refdes=self.refdes))
             valid = False
         for i in range(min(len(comp_data), self.get_child_count())):
-            ok, sub_errors = self.get_child_node_by_idx(i).is_valid_errors(comp_data[i])
+            ok, sub_errors = self.children[i].is_valid_errors(comp_data[i])
             valid &= ok
             errors += sub_errors
         for i in range(min(len(comp_data), self.get_child_count()), self.get_child_count()):
             if i < self.get_child_count():
-                ok, sub_errors = self.get_child_node_by_idx(i).is_valid_errors(None)
+                ok, sub_errors = self.children[i].is_valid_errors(None)
                 valid &= ok
                 errors += sub_errors
         return valid, errors

--- a/pyx12/map_if/_element.py
+++ b/pyx12/map_if/_element.py
@@ -14,14 +14,19 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import Any, cast
+from typing import TYPE_CHECKING, cast
 from xml.etree.ElementTree import Element
+
+import pyx12.segment
 
 from .. import validation
 from ..dataele import _DataEle
 from ..error_item import EleError
 from ..errors import EngineError
 from ._base import _required_attr, x12_node
+
+if TYPE_CHECKING:
+    from ._root import map_if
 
 
 ############################################################
@@ -32,7 +37,7 @@ class element_if(x12_node):
     Element Interface
     """
 
-    root: Any
+    root: map_if
     base_name: str
     valid_codes: list[str | None]
     _valid_codes_set: frozenset[str | None]
@@ -41,12 +46,11 @@ class element_if(x12_node):
     refdes: str | None
     data_ele: str | None
     _data_ele: _DataEle | None
-    usage: str | None
     seq: int
     max_use: str | None
     res: str | None
 
-    def __init__(self, root: Any, parent: Any, elem: Element) -> None:
+    def __init__(self, root: map_if, parent: x12_node, elem: Element) -> None:
         """
         :param parent: parent node
         """
@@ -118,7 +122,7 @@ class element_if(x12_node):
     def _resolve_data_ele(self) -> _DataEle:
         if self._data_ele is not None:
             return self._data_ele
-        return cast(_DataEle, self.root.data_elements.get_by_elem_num(self.data_ele))
+        return self.root.data_elements.get_by_elem_num(self.data_ele)
 
     def _ele_error(self, err_cde: str, err_str: str, err_val: str | None) -> EleError:
         return EleError(
@@ -137,7 +141,7 @@ class element_if(x12_node):
         """
         return code in self._valid_codes_set
 
-    def get_parent(self) -> Any:
+    def get_parent(self) -> x12_node | None:
         """
         :return: ref to parent class instance
         """
@@ -152,7 +156,9 @@ class element_if(x12_node):
         raise NotImplementedError("Override in sub-class")
 
     def is_valid_errors(
-        self, elem: Any, type_list: list[str | None] | None = None
+        self,
+        elem: pyx12.segment.Element | pyx12.segment.Composite | None,
+        type_list: list[str | None] | None = None,
     ) -> tuple[bool, list[EleError]]:
         """
         Pure validator: returns (ok, errors) without touching an error handler.
@@ -191,6 +197,8 @@ class element_if(x12_node):
     def _validate_when_empty(self) -> list[EleError]:
         if self.usage in ("N", "S"):
             return []
+        # An element's parent is a composite_if or a segment_if at runtime.
+        assert self.parent is not None
         if self.usage == "R" and (
             self.seq != 1 or not self.parent.is_composite() or self.parent.usage == "R"
         ):
@@ -257,7 +265,10 @@ class element_if(x12_node):
     def _validate_data_type(self, elem_val: str) -> list[EleError]:
         data_type = self._resolve_data_ele()["data_type"]
         if validation.IsValidDataType(
-            elem_val, cast(str, data_type), self.root.param.get("charset"), self.root.icvn
+            elem_val,
+            cast(str, data_type),
+            self.root.param.get("charset"),
+            self.root.icvn or "00401",
         ):
             return []
         if data_type in ("RD8", "DT", "D8", "D6"):
@@ -363,14 +374,18 @@ class element_if(x12_node):
         if self._fullpath:
             return self._fullpath
         # get enclosing loop
-        parent_path = self.get_parent_segment().parent.get_path()
+        seg = self.get_parent_segment()
+        assert seg.parent is not None
+        parent_path = seg.parent.get_path()
         # add the segment, element, and sub-element path
         self._fullpath = parent_path + "/" + (self.id or "")
         return self._fullpath
 
-    def get_parent_segment(self) -> Any:
-        # pop to enclosing loop
+    def get_parent_segment(self) -> x12_node:
+        # An element is always nested inside a segment (directly, or via a composite).
         p = self.parent
+        assert p is not None
         while not p.is_segment():
             p = p.parent
+            assert p is not None
         return p

--- a/pyx12/map_if/_loader.py
+++ b/pyx12/map_if/_loader.py
@@ -20,10 +20,11 @@ from typing import IO, Any
 import defusedxml.ElementTree as et
 
 from ..errors import EngineError
+from ..params import ParamsBase
 from ._root import map_if
 
 
-def load_map_file(map_file: str, param: Any, map_path: str | None = None) -> map_if:
+def load_map_file(map_file: str, param: ParamsBase, map_path: str | None = None) -> map_if:
     """
     Create the map object from a file
 

--- a/pyx12/map_if/_loop.py
+++ b/pyx12/map_if/_loop.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING
 from xml.etree.ElementTree import Element
 
 import pyx12.segment
@@ -23,6 +23,9 @@ from ..errors import EngineError
 from ..path import X12Path
 from ._base import MAXINT, _required_attr, x12_node
 from ._segment import segment_if
+
+if TYPE_CHECKING:
+    from ._root import map_if
 
 
 ############################################################
@@ -33,16 +36,15 @@ class loop_if(x12_node):
     Loop Interface
     """
 
-    root: Any
-    pos_map: dict[int, list[Any]]
+    root: map_if
+    pos_map: dict[int, list[x12_node]]
     base_name: str
     _cur_count: int
     type: str | None
-    usage: str | None
     pos: int
     repeat: str | None
 
-    def __init__(self, root: Any, parent: Any, elem: Element) -> None:
+    def __init__(self, root: map_if, parent: x12_node, elem: Element) -> None:
         """ """
         x12_node.__init__(self)
         self.root = root
@@ -76,16 +78,17 @@ class loop_if(x12_node):
         # For the segments with duplicate ordinals, adjust the path to be unique
         for ord1 in sorted(self.pos_map):
             if len(self.pos_map[ord1]) > 1:
-                for seg_node in [n for n in self.pos_map[ord1] if n.is_segment()]:
+                for seg_node in [n for n in self.pos_map[ord1] if isinstance(n, segment_if)]:
                     id_elem = seg_node.guess_unique_key_id_element()
                     if id_elem is not None:
-                        seg_node.path = seg_node.path + "[" + id_elem.valid_codes[0] + "]"
+                        seg_node.path = seg_node.path + "[" + (id_elem.valid_codes[0] or "") + "]"
 
     def debug_print(self) -> None:
         sys.stdout.write(self.__repr__())
         for ord1 in sorted(self.pos_map):
             for node in self.pos_map[ord1]:
-                node.debug_print()
+                if isinstance(node, (loop_if, segment_if)):
+                    node.debug_print()
 
     def __len__(self) -> int:
         i = 0
@@ -118,28 +121,28 @@ class loop_if(x12_node):
             return MAXINT
         return int(self.repeat)
 
-    def get_parent(self) -> Any:
+    def get_parent(self) -> x12_node | None:
         return self.parent
 
-    def get_first_node(self) -> Any:
+    def get_first_node(self) -> x12_node | None:
         pos_keys = sorted(self.pos_map)
         if len(pos_keys) > 0:
             return self.pos_map[pos_keys[0]][0]
         else:
             return None
 
-    def get_first_seg(self) -> Any:
+    def get_first_seg(self) -> segment_if | None:
         first = self.get_first_node()
-        if first.is_segment():
+        if isinstance(first, segment_if):
             return first
         else:
             return None
 
-    def childIterator(self) -> Iterator[Any]:
+    def childIterator(self) -> Iterator[x12_node]:
         for ord1 in sorted(self.pos_map):
             yield from self.pos_map[ord1]
 
-    def getnodebypath(self, spath: str) -> Any:
+    def getnodebypath(self, spath: str) -> x12_node | None:
         """
         :param spath: remaining path to match
         :type spath: string
@@ -150,13 +153,14 @@ class loop_if(x12_node):
             return None
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
-                if child.is_loop():
+                assert child.id is not None
+                if isinstance(child, loop_if):
                     if child.id.upper() == pathl[0].upper():
                         if len(pathl) == 1:
                             return child
                         else:
                             return child.getnodebypath("/".join(pathl[1:]))
-                elif child.is_segment() and len(pathl) == 1:
+                elif isinstance(child, segment_if) and len(pathl) == 1:
                     if pathl[0].find("[") == -1:  # No id to match
                         if pathl[0] == child.id:
                             return child
@@ -169,7 +173,7 @@ class loop_if(x12_node):
                                 return child
         raise EngineError('getnodebypath failed. Path "%s" not found' % spath)
 
-    def getnodebypath2(self, path_str: str) -> Any:
+    def getnodebypath2(self, path_str: str) -> x12_node | None:
         """
         Try x12 path
 
@@ -182,7 +186,8 @@ class loop_if(x12_node):
             return None
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
-                if child.is_loop() and len(x12path.loop_list) > 0:
+                assert child.id is not None
+                if isinstance(child, loop_if) and len(x12path.loop_list) > 0:
                     if child.id.upper() == x12path.loop_list[0].upper():
                         if len(x12path.loop_list) == 1 and x12path.seg_id is None:
                             return child
@@ -190,7 +195,7 @@ class loop_if(x12_node):
                             del x12path.loop_list[0]
                             return child.getnodebypath2(x12path.format())
                 elif (
-                    child.is_segment()
+                    isinstance(child, segment_if)
                     and len(x12path.loop_list) == 0
                     and x12path.seg_id is not None
                 ):
@@ -209,7 +214,7 @@ class loop_if(x12_node):
     def get_child_count(self) -> int:
         return self.__len__()
 
-    def get_child_node_by_idx(self, idx: int) -> Any:
+    def get_child_node_by_idx(self, idx: int) -> x12_node | None:
         """
         :param idx: zero based
         """
@@ -241,9 +246,9 @@ class loop_if(x12_node):
         """
         pos_keys = sorted(self.pos_map)
         child = self.pos_map[pos_keys[0]][0]
-        if child.is_loop():
+        if isinstance(child, loop_if):
             return bool(child.is_match(seg_data))
-        elif child.is_segment():
+        elif isinstance(child, segment_if):
             if child.is_match(seg_data):
                 return True
             else:
@@ -251,21 +256,21 @@ class loop_if(x12_node):
         else:
             return False
 
-    def get_child_seg_node(self, seg_data: pyx12.segment.Segment) -> Any:
+    def get_child_seg_node(self, seg_data: pyx12.segment.Segment) -> segment_if | None:
         """
         Return the child segment matching the segment data
         """
         for child in self.childIterator():
-            if child.is_segment() and child.is_match(seg_data):
+            if isinstance(child, segment_if) and child.is_match(seg_data):
                 return child
         return None
 
-    def get_child_loop_node(self, seg_data: pyx12.segment.Segment) -> Any:
+    def get_child_loop_node(self, seg_data: pyx12.segment.Segment) -> loop_if | None:
         """
         Return the child segment matching the segment data
         """
         for child in self.childIterator():
-            if child.is_loop() and child.is_match(seg_data):
+            if isinstance(child, loop_if) and child.is_match(seg_data):
                 return child
         return None
 
@@ -303,9 +308,11 @@ class loop_if(x12_node):
         """
         raise DeprecationWarning("Moved to nodeCounter")
 
-    def loop_segment_iterator(self) -> Iterator[Any]:
+    def loop_segment_iterator(self) -> Iterator[x12_node]:
         yield self
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
-                if child.is_loop() or child.is_segment():
+                if isinstance(child, loop_if):
                     yield from child.loop_segment_iterator()
+                elif isinstance(child, segment_if):
+                    yield child

--- a/pyx12/map_if/_root.py
+++ b/pyx12/map_if/_root.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 import os.path
 import sys
 from collections.abc import Iterator
-from typing import Any, cast
 from xml.etree.ElementTree import Element
 
 from .. import codes, dataele
 from ..errors import EngineError
+from ..params import ParamsBase
 from ..path import X12Path
 from ._base import x12_node
+from ._element import element_if
 from ._loop import loop_if
 from ._segment import segment_if
 
@@ -32,15 +33,15 @@ class map_if(x12_node):
     Map file interface
     """
 
-    pos_map: dict[int, list[Any]]
+    pos_map: dict[int, list[x12_node]]
     cur_path: str
-    param: Any
+    param: ParamsBase
     ext_codes: codes.ExternalCodes
     data_elements: dataele.DataElements
     base_name: str
     icvn: str | None
 
-    def __init__(self, eroot: Element, param: Any, base_path: str | None = None) -> None:
+    def __init__(self, eroot: Element, param: ParamsBase, base_path: str | None = None) -> None:
         """
         :param eroot: ElementTree root
         :param param: map of parameters
@@ -82,8 +83,11 @@ class map_if(x12_node):
         """
         ipath = "/ISA_LOOP/ISA"
         try:
-            node = self.getnodebypath(ipath).children[11]
-            return cast(str, node.valid_codes[0])
+            isa = self.getnodebypath(ipath)
+            assert isinstance(isa, segment_if)
+            node = isa.children[11]
+            assert isinstance(node, element_if)
+            return node.valid_codes[0]
         except Exception:
             return None
 
@@ -110,16 +114,16 @@ class map_if(x12_node):
     def get_child_count(self) -> int:
         return self.__len__()
 
-    def get_first_node(self) -> Any:
+    def get_first_node(self) -> x12_node | None:
         pos_keys = sorted(self.pos_map)
         if len(pos_keys) > 0:
             return self.pos_map[pos_keys[0]][0]
         else:
             return None
 
-    def get_first_seg(self) -> Any:
+    def get_first_seg(self) -> segment_if | None:
         first = self.get_first_node()
-        if first.is_segment():
+        if isinstance(first, segment_if):
             return first
         else:
             return None
@@ -142,13 +146,13 @@ class map_if(x12_node):
         """
         return self.path
 
-    def get_child_node_by_idx(self, idx: int) -> Any:
+    def get_child_node_by_idx(self, idx: int) -> x12_node | None:
         """
         :param idx: zero based
         """
         raise EngineError("map_if.get_child_node_by_idx is not a valid call")
 
-    def getnodebypath(self, spath: str) -> Any:
+    def getnodebypath(self, spath: str) -> x12_node | None:
         """
         :param spath: Path string; /1000/2000/2000A/NM102-3
         :type spath: string
@@ -156,9 +160,9 @@ class map_if(x12_node):
         pathl = spath.split("/")[1:]
         if len(pathl) == 0:
             return None
-        # logger.debug('%s %s %s' % (self.base_name, self.id, pathl[1]))
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
+                assert child.id is not None
                 if child.id.lower() == pathl[0].lower():
                     if len(pathl) == 1:
                         return child
@@ -166,7 +170,7 @@ class map_if(x12_node):
                         return child.getnodebypath("/".join(pathl[1:]))
         raise EngineError('getnodebypath failed. Path "%s" not found' % spath)
 
-    def getnodebypath2(self, path_str: str) -> Any:
+    def getnodebypath2(self, path_str: str) -> x12_node | None:
         """
         :param path: Path string; /1000/2000/2000A/NM102-3
         :type path: string
@@ -176,12 +180,15 @@ class map_if(x12_node):
             return None
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
+                assert child.id is not None
                 if child.id.upper() == x12path.loop_list[0]:
                     if len(x12path.loop_list) == 1:
                         return child
                     else:
                         del x12path.loop_list[0]
-                        return child.getnodebypath2(x12path.format())
+                        if isinstance(child, loop_if):
+                            return child.getnodebypath2(x12path.format())
+                        return None
         raise EngineError('getnodebypath2 failed. Path "%s" not found' % path_str)
 
     def is_map_root(self) -> bool:
@@ -205,9 +212,11 @@ class map_if(x12_node):
     def __iter__(self) -> map_if:
         return self
 
-    def loop_segment_iterator(self) -> Iterator[Any]:
+    def loop_segment_iterator(self) -> Iterator[x12_node]:
         yield self
         for ord1 in sorted(self.pos_map):
             for child in self.pos_map[ord1]:
-                if child.is_loop() or child.is_segment():
+                if isinstance(child, loop_if):
                     yield from child.loop_segment_iterator()
+                elif isinstance(child, segment_if):
+                    yield child

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from xml.etree.ElementTree import Element
 
 import pyx12.segment
@@ -26,6 +26,9 @@ from ..syntax import is_syntax_valid
 from ._base import MAXINT, _required_attr, x12_node
 from ._composite import composite_if
 from ._element import element_if
+
+if TYPE_CHECKING:
+    from ._root import map_if
 
 
 def apply_segment_errors(node: segment_if, seg_data: pyx12.segment.Segment, errh: Any) -> bool:
@@ -49,18 +52,18 @@ class segment_if(x12_node):
     Segment Interface
     """
 
-    root: Any
+    root: map_if
+    children: list[element_if | composite_if]  # type: ignore[assignment]
     base_name: str
     _cur_count: int
     syntax: list[list[Any]]
     type: str | None
-    usage: str | None
     pos: int
     max_use: str | None
     repeat: str | None
     end_tag: str | None
 
-    def __init__(self, root: Any, parent: Any, elem: Element) -> None:
+    def __init__(self, root: map_if, parent: x12_node, elem: Element) -> None:
         """
         :param parent: parent node
         """
@@ -124,7 +127,7 @@ class segment_if(x12_node):
         out += "\n"
         return out
 
-    def get_child_node_by_idx(self, idx: int) -> Any:
+    def get_child_node_by_idx(self, idx: int) -> element_if | composite_if | None:
         """
         :param idx: zero based
         """
@@ -137,7 +140,7 @@ class segment_if(x12_node):
             else:
                 raise EngineError("idx %i not found in %s" % (idx, self.id))
 
-    def get_child_node_by_ordinal(self, ord: int) -> Any:
+    def get_child_node_by_ordinal(self, ord: int) -> element_if | composite_if | None:
         """
         Get a child element or composite by the X12 ordinal
         :param ord: one based element/composite index.  Corresponds to the map <seq> element
@@ -145,7 +148,7 @@ class segment_if(x12_node):
         """
         return self.get_child_node_by_idx(ord - 1)
 
-    def getnodebypath2(self, path_str: str) -> Any:
+    def getnodebypath2(self, path_str: str) -> x12_node | None:
         """
         Try x12 path
 
@@ -161,14 +164,16 @@ class segment_if(x12_node):
         ele = self.get_child_node_by_ordinal(x12path.ele_idx)
         if x12path.subele_idx is None:
             return ele
-        return ele.get_child_node_by_ordinal(x12path.subele_idx)
+        if isinstance(ele, composite_if):
+            return ele.get_child_node_by_ordinal(x12path.subele_idx)
+        return None
 
     def get_max_repeat(self) -> int:
         if self.max_use is None or self.max_use == ">1":
             return MAXINT
         return int(self.max_use)
 
-    def get_parent(self) -> Any:
+    def get_parent(self) -> x12_node | None:
         """
         :return: ref to parent class instance
         :rtype: pyx12.x12_node
@@ -179,7 +184,10 @@ class segment_if(x12_node):
         """
         :rtype: boolean
         """
-        if self is self.get_parent().get_first_seg():
+        from ._loop import loop_if  # local import: loop_if imports segment_if at module load
+
+        parent = self.get_parent()
+        if isinstance(parent, loop_if) and self is parent.get_first_seg():
             return True
         else:
             return False
@@ -230,7 +238,7 @@ class segment_if(x12_node):
 
     def _resolve_unique_key_field(
         self, seg_id: str | None, *, with_qual: bool
-    ) -> tuple[Any, int, int | None] | None:
+    ) -> tuple[element_if, int, int | None] | None:
         """
         Locate the child node carrying this segment's qualifier (if any).
 
@@ -242,117 +250,113 @@ class segment_if(x12_node):
         composite as a valid qualifier carrier; ``with_qual=True`` (used by
         ``is_match_qual``) only honors ID-typed qualifier fields.
         """
-        # Element at position 01 ??? the common case
+        c0 = self.children[0] if len(self.children) > 0 else None
+        c1 = self.children[1] if len(self.children) > 1 else None
+        c2 = self.children[2] if len(self.children) > 2 else None
+        # Element at position 01 — the common case
         if (
-            self.children[0].is_element()
-            and self.children[0].get_data_type() == "ID"
-            and self.children[0].usage == "R"
-            and len(self.children[0].valid_codes) > 0
+            isinstance(c0, element_if)
+            and c0.get_data_type() == "ID"
+            and c0.usage == "R"
+            and len(c0.valid_codes) > 0
         ):
-            return (self.children[0], 1, None)
+            return (c0, 1, None)
         # ENT-segment carries its qualifier at element 02 (820 special case)
         if (
             seg_id == "ENT"
-            and self.children[1].is_element()
-            and self.children[1].get_data_type() == "ID"
-            and len(self.children[1].valid_codes) > 0
+            and isinstance(c1, element_if)
+            and c1.get_data_type() == "ID"
+            and len(c1.valid_codes) > 0
         ):
-            return (self.children[1], 2, None)
+            return (c1, 2, None)
         # CTX-segment can have an AN-typed composite at 01-1 (999 special case);
         # is_match_qual ignores this branch.
         if (
             not with_qual
             and seg_id == "CTX"
-            and self.children[0].is_composite()
-            and self.children[0].children[0].get_data_type() == "AN"
-            and len(self.children[0].children[0].valid_codes) > 0
+            and isinstance(c0, composite_if)
+            and c0.children[0].get_data_type() == "AN"
+            and len(c0.children[0].valid_codes) > 0
         ):
-            return (self.children[0].children[0], 1, 1)
+            return (c0.children[0], 1, 1)
         # General ID-typed composite at 01-1
         if (
-            self.children[0].is_composite()
-            and self.children[0].children[0].get_data_type() == "ID"
-            and len(self.children[0].children[0].valid_codes) > 0
+            isinstance(c0, composite_if)
+            and c0.children[0].get_data_type() == "ID"
+            and len(c0.children[0].valid_codes) > 0
         ):
-            return (self.children[0].children[0], 1, 1)
+            return (c0.children[0], 1, 1)
         # HL-segment carries its qualifier at element 03
-        if (
-            seg_id == "HL"
-            and self.children[2].is_element()
-            and len(self.children[2].valid_codes) > 0
-        ):
-            return (self.children[2], 3, None)
+        if seg_id == "HL" and isinstance(c2, element_if) and len(c2.valid_codes) > 0:
+            return (c2, 3, None)
         return None
 
-    def guess_unique_key_id_element(self) -> Any:
+    def guess_unique_key_id_element(self) -> element_if | None:
         """
         Some segments, like REF, DTP, and DTP are duplicated.  They are matched using the value of an ID element.
         Which element to use varies.  This function tries to find a good candidate.
         """
-        if (
-            self.children[0].is_element()
-            and self.children[0].get_data_type() == "ID"
-            and len(self.children[0].valid_codes) > 0
-        ):
-            return self.children[0]
+        c0 = self.children[0] if len(self.children) > 0 else None
+        c1 = self.children[1] if len(self.children) > 1 else None
+        c2 = self.children[2] if len(self.children) > 2 else None
+        if isinstance(c0, element_if) and c0.get_data_type() == "ID" and len(c0.valid_codes) > 0:
+            return c0
         # Special Case for 820
         elif (
             self.id == "ENT"
-            and self.children[1].is_element()
-            and self.children[1].get_data_type() == "ID"
-            and len(self.children[1].valid_codes) > 0
+            and isinstance(c1, element_if)
+            and c1.get_data_type() == "ID"
+            and len(c1.valid_codes) > 0
         ):
-            return self.children[1]
+            return c1
         elif (
-            self.children[0].is_composite()
-            and self.children[0].children[0].get_data_type() == "ID"
-            and len(self.children[0].children[0].valid_codes) > 0
+            isinstance(c0, composite_if)
+            and c0.children[0].get_data_type() == "ID"
+            and len(c0.children[0].valid_codes) > 0
         ):
-            return self.children[0].children[0]
-        elif (
-            self.id == "HL"
-            and self.children[2].is_element()
-            and len(self.children[2].valid_codes) > 0
-        ):
-            return self.children[2]
+            return c0.children[0]
+        elif self.id == "HL" and isinstance(c2, element_if) and len(c2.valid_codes) > 0:
+            return c2
         return None
 
-    def get_unique_key_id_element(self, id_val: str) -> Any:
+    def get_unique_key_id_element(self, id_val: str) -> element_if | None:
         """
         Some segments, like REF, DTP, and DTP are duplicated.  They are matched using the value of an ID element.
         Which element to use varies.  This function tries to find a good candidate, using a key value
         """
-
+        c0 = self.children[0] if len(self.children) > 0 else None
+        c1 = self.children[1] if len(self.children) > 1 else None
+        c2 = self.children[2] if len(self.children) > 2 else None
         if (
-            self.children[0].is_element()
-            and self.children[0].get_data_type() == "ID"
-            and len(self.children[0].valid_codes) > 0
-            and id_val in self.children[0]._valid_codes_set
+            isinstance(c0, element_if)
+            and c0.get_data_type() == "ID"
+            and len(c0.valid_codes) > 0
+            and id_val in c0._valid_codes_set
         ):
-            return self.children[0]
+            return c0
         # Special Case for 820
         elif (
             self.id == "ENT"
-            and self.children[1].is_element()
-            and self.children[1].get_data_type() == "ID"
-            and len(self.children[1].valid_codes) > 0
-            and id_val in self.children[1]._valid_codes_set
+            and isinstance(c1, element_if)
+            and c1.get_data_type() == "ID"
+            and len(c1.valid_codes) > 0
+            and id_val in c1._valid_codes_set
         ):
-            return self.children[1]
+            return c1
         elif (
-            self.children[0].is_composite()
-            and self.children[0].children[0].get_data_type() == "ID"
-            and len(self.children[0].children[0].valid_codes) > 0
-            and id_val in self.children[0].children[0]._valid_codes_set
+            isinstance(c0, composite_if)
+            and c0.children[0].get_data_type() == "ID"
+            and len(c0.children[0].valid_codes) > 0
+            and id_val in c0.children[0]._valid_codes_set
         ):
-            return self.children[0].children[0]
+            return c0.children[0]
         elif (
             self.id == "HL"
-            and self.children[2].is_element()
-            and len(self.children[2].valid_codes) > 0
-            and id_val in self.children[2]._valid_codes_set
+            and isinstance(c2, element_if)
+            and len(c2.valid_codes) > 0
+            and id_val in c2._valid_codes_set
         ):
-            return self.children[2]
+            return c2
         return None
 
     def is_segment(self) -> bool:
@@ -390,12 +394,16 @@ class segment_if(x12_node):
         type_list: list[str | None] = []
         for i in range(min(len(seg_data), child_count)):
             child_node = self.get_child_node_by_idx(i)
-            if child_node.is_composite():
+            if isinstance(child_node, composite_if):
                 ref_des = "%02i" % (i + 1)
                 comp_data = seg_data.get(ref_des)
+                # When the map says the position holds a composite, seg_data.get
+                # returns either a Composite or None — Element only appears for
+                # element-typed positions.
+                assert comp_data is None or isinstance(comp_data, pyx12.segment.Composite)
                 subele_count = child_node.get_child_count()
                 if seg_data.ele_len(ref_des) > subele_count and child_node.usage != "N":
-                    subele_node = child_node.get_child_node_by_idx(subele_count + 1)
+                    subele_node = child_node.children[subele_count + 1]
                     err_str = 'Too many sub-elements in composite "%s" (%s)' % (
                         subele_node.name,
                         subele_node.refdes,
@@ -412,7 +420,7 @@ class segment_if(x12_node):
                 ok, comp_errors = child_node.is_valid_errors(comp_data)
                 valid &= ok
                 errors += comp_errors
-            elif child_node.is_element():
+            elif isinstance(child_node, element_if):
                 if (
                     i == 1
                     and seg_data.get_seg_id() == "DTP"
@@ -433,9 +441,14 @@ class segment_if(x12_node):
 
         for i in range(min(len(seg_data), child_count), child_count):
             child_node = self.get_child_node_by_idx(i)
-            ok, child_errors = child_node.is_valid_errors(None)
-            valid &= ok
-            errors += child_errors
+            if isinstance(child_node, composite_if):
+                ok, child_errors = child_node.is_valid_errors(None)
+                valid &= ok
+                errors += child_errors
+            elif isinstance(child_node, element_if):
+                ok, child_errors = child_node.is_valid_errors(None)
+                valid &= ok
+                errors += child_errors
 
         for syn in self.syntax:
             bResult, syn_err = is_syntax_valid(seg_data, syn)
@@ -487,5 +500,5 @@ class segment_if(x12_node):
         """
         raise DeprecationWarning("Moved to nodeCounter")
 
-    def loop_segment_iterator(self) -> Iterator[Any]:
+    def loop_segment_iterator(self) -> Iterator[x12_node]:
         yield self

--- a/pyx12/x12metadata.py
+++ b/pyx12/x12metadata.py
@@ -157,6 +157,8 @@ def get_x12file_metadata(
             st_data["TransactionSetCreationTime"] = seg.get_value("BHT05")
             st_data["ClaimorEncounterIdentifier"] = seg.get_value("BHT06")
 
+        assert isinstance(node, pyx12.map_if.segment_if)
+        assert node.parent is not None
         x12path = node.get_path()
         # parent
         if do_node_summary and node_summary is not None:
@@ -180,8 +182,10 @@ def get_x12file_metadata(
 
             for refdes, ele_ord, comp_ord, val in seg.values_iterator():
                 ele_node = node.getnodebypath2(refdes)
-                if ele_node.is_composite():
+                if isinstance(ele_node, pyx12.map_if.composite_if):
                     ele_node = ele_node.get_child_node_by_ordinal(1)
+                assert isinstance(ele_node, pyx12.map_if.element_if)
+                assert ele_node.parent is not None
                 elepath = ele_node.get_path()
 
                 if elepath in node_summary:

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -206,6 +206,7 @@ def x12n_document(
                 errh.handle_errors(src.pop_errors())
 
             # errh.set_cur_line(src.get_cur_line())
+            assert isinstance(node, pyx12.map_if.segment_if)
             valid &= apply_segment_errors(node, seg, errh)
             # erx.handleErrors(src.pop_errors())
             # erx.handleErrors(errh.get_errors())
@@ -216,7 +217,7 @@ def x12n_document(
             except Exception:
                 logger.error("callback failed")
         if fd_html:
-            if node is not None and node.is_first_seg_in_loop():
+            if isinstance(node, pyx12.map_if.segment_if) and node.is_first_seg_in_loop():
                 html.loop(node.get_parent())
             err_node_list: list[Any] = []
             while True:


### PR DESCRIPTION
## Summary

Replace `Any` cross-node and runtime-payload annotations across the `map_if` package with concrete types from the existing class hierarchy and from `pyx12.segment`. Use `TYPE_CHECKING` imports for the recursive `map_if` root reference.

`Any` count in `pyx12/map_if/` drops from **58 to 7** (remaining are `errh: Any`, `syntax: list[list[Any]]`, and `IO[Any]` in the loader — all out-of-scope per the plan).

## What changed

**`pyx12/map_if/_base.py`** — base class:
- `parent: Any` → `x12_node | None`; `children: list[Any]` → `list[x12_node]`.
- Promoted `usage: str | None` to the base (every subclass duplicated it).
- New no-op `debug_print()` / `xml()` defaults so iteration over a `list[x12_node]` doesn't fail when only some subclasses define them.
- `getnodebypath`, `get_child_node_by_idx`, `get_child_node_by_ordinal` return `x12_node | None`.

**`_loop.py` / `_segment.py` / `_composite.py` / `_element.py`** — subclasses:
- `root: Any` → `map_if` (via `TYPE_CHECKING`).
- `parent: Any` → `x12_node`.
- `pos_map: dict[int, list[Any]]` → `dict[int, list[x12_node]]` (loop + root).
- Children narrowed: `list[element_if | composite_if]` (segment), `list[element_if]` (composite).
- Method return types tightened across the public surface (`get_first_node`, `get_first_seg`, `childIterator`, `getnodebypath`, `loop_segment_iterator`, etc.).
- `comp_data: Any` → `pyx12.segment.Composite | None`.
- `elem: Any` → `pyx12.segment.Element | pyx12.segment.Composite | None` (validator accepts `Composite` to flag the "passed-composite-to-element-node" error case, code 6).
- Where the existing code used `child.is_element()` / `is_composite()` to discriminate, switch to `isinstance(child, element_if/composite_if)` inside `map_if/` so mypy can narrow. The discriminator methods are kept as runtime predicates.

**`_root.py`** — `param: Any` → `ParamsBase`. Replace `cast()` with isinstance assertions for `_get_icvn`.

**`_loader.py`** — `load_map_file(param: Any)` → `ParamsBase`.

**`x12n_document.py` + `x12metadata.py`** — added isinstance assertions at three sites where the orchestrator pulls a node out of the map and immediately treats it as a `segment_if` (validation site, metadata summary site).

## Why no Protocol

The `x12_node` base hierarchy already plays the role a `Protocol` would. There is no second implementation; every node inherits from `x12_node`. Adding a `Protocol` would shadow the concrete inheritance without removing any `Any` annotation. See [the plan](.claude/plans/radiant-petting-steele.md) for the full rationale.

## Why no TypeGuard

Tried it. `TypeGuard` on instance methods narrows the first non-`self` positional argument, not `self` — so `def is_loop(self) -> TypeGuard[loop_if]` doesn't actually narrow the receiver in mypy. `TypeIs` (PEP 742) would, but it's only in `typing` from Python 3.13 (pyx12 targets 3.11+). Practical alternative: use `isinstance(node, loop_if)` at the few sites that need narrowing.

## Test plan

- [x] `pytest pyx12/test/` — 535/535 pass
- [x] `mypy --strict pyx12/` — clean across all 82 source files
- [x] `ruff format` + `ruff check` — clean
- [ ] CI green
- [ ] `check_maps` CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)