### PR TITLE
fix: initialize err_handler.ele_node_added in __init__

### DIFF
--- a/pyx12/error_handler.py
+++ b/pyx12/error_handler.py
@@ -112,6 +112,7 @@ class err_handler:
         self.cur_seg_node = None
         self.seg_node_added = False
         self.cur_ele_node = None
+        self.ele_node_added = False
         self.cur_line = 0
 
     def accept(self, visitor: Any) -> None:

--- a/pyx12/test/test_error_handler.py
+++ b/pyx12/test/test_error_handler.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock
+
+from pyx12.error_handler import err_handler
+
+
+class TestErrHandlerInit(unittest.TestCase):
+    def test_ele_node_added_initialized(self):
+        # Both bookkeeping flags must be initialized in __init__ — see
+        # test_ele_error_before_add_ele_does_not_raise for why this matters.
+        eh = err_handler()
+        self.assertFalse(eh.ele_node_added)
+
+    def test_seg_node_added_initialized(self):
+        eh = err_handler()
+        self.assertFalse(eh.seg_node_added)
+
+
+class TestEleErrorBeforeAddEle(unittest.TestCase):
+    def test_ele_error_before_add_ele_does_not_raise(self):
+        # Regression for the call chain x12n_document.x12n_document ->
+        # apply_segment_errors -> err_handler.ele_error -> _add_cur_ele,
+        # which reads self.ele_node_added. apply_segment_errors iterates
+        # element-level errors discovered during segment validation and
+        # calls ele_error directly without going through add_ele, so on a
+        # fresh err_handler ele_node_added would be unset and reading it
+        # raised AttributeError.
+        eh = err_handler()
+        # Simulate state after a segment has been added but no element has
+        # yet been added (apply_segment_errors emits element-level errors
+        # without going through add_ele first).
+        eh.cur_seg_node = MagicMock()
+        eh.cur_seg_node.get_cur_line.return_value = 1
+        eh.cur_seg_node.elements = []
+        eh.seg_node_added = True
+        eh.cur_ele_node = MagicMock()
+        eh.ele_error("8", "Invalid Code Value", "bad", "REF02")
+        self.assertTrue(eh.ele_node_added)
+        self.assertEqual(len(eh.cur_seg_node.elements), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `err_handler.__init__` was missing one line: `self.ele_node_added = False`
- `seg_node_added` is initialized but `ele_node_added` is only declared as a class-level type annotation, so reading it before any `add_ele()` call raises `AttributeError`
- Found while running x12 validation against a file with element-level errors via the `swmbh-x12-sbus` worker on pyx12 4.0.0rc1

## Repro from production traceback
```
File ".../pyx12/x12n_document.py", line 210, in x12n_document
    valid &= apply_segment_errors(node, seg, errh)
File ".../pyx12/map_if/_segment.py", line 46, in apply_segment_errors
    errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)
File ".../pyx12/error_handler.py", line 313, in ele_error
    self._add_cur_ele()
File ".../pyx12/error_handler.py", line 228, in _add_cur_ele
    if not self.ele_node_added and self.cur_seg_node is not None:
AttributeError: 'err_handler' object has no attribute 'ele_node_added'.
                Did you mean: 'seg_node_added'?
```

`apply_segment_errors` calls `ele_error` directly for each element-level error discovered during segment validation. That path skips `add_ele` (which would have set `self.ele_node_added = False`), so `_add_cur_ele` reads an attribute that was never created.

## Fix
One-line addition to `__init__`, parallel to the existing `seg_node_added = False`.

## Tests
New `pyx12/test/test_error_handler.py` with:
- `test_ele_node_added_initialized` / `test_seg_node_added_initialized` — unit tests on the constructor
- `test_ele_error_before_add_ele_does_not_raise` — integration regression that exercises the `ele_error -> _add_cur_ele` call path that produced the original stacktrace; fails on master with the documented `AttributeError`, passes with the fix

Verified by reverting the fix locally — the integration test reproduces the exact AttributeError from the production trace.

## Test plan
- [x] `pytest pyx12/test/` — 538/538 pass (535 existing + 3 new)
- [x] Test fails as expected without the fix; passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)