### PR TITLE
chore: bump version to 4.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyx12"
-version = "4.0.0rc1"
+version = "4.0.0rc2"
 description = "HIPAA X12 validator, parser and converter"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyx12/version.py
+++ b/pyx12/version.py
@@ -1,1 +1,1 @@
-__version__ = "4.0.0rc1"
+__version__ = "4.0.0rc2"


### PR DESCRIPTION
## Summary

Second release candidate for **4.0.0**. Pulls in #158 (init `err_handler.ele_node_added`).

## What changed since rc1

- **#158 fix:** `err_handler.__init__` was missing one line (`self.ele_node_added = False`), causing `AttributeError` when `apply_segment_errors` emits seg-level errors (composite-required `"1"`, syntax `"2"`/`"10"`) that skip `add_ele`. Surfaced via real production traffic. Test added to lock the regression in.

## Pre-flight verification

- [x] `pytest pyx12/test/` — 538/538 pass (535 + 3 new from #158)
- [x] `mypy --strict pyx12/` — clean across 83 source files
- [x] `ruff format` + `ruff check` — clean
- [x] `tools/check_maps.py` — 32 maps clean
- [x] `tools/test_install.py` — post-packaging smoke suite green
- [ ] CI green
- [ ] `check_maps` CI gate green
- [ ] Post-packaging install regression CI job green

## Next steps

After this PR merges:
1. Tag `v4.0.0rc2` on master.
2. Push tag → `release.yml` workflow publishes to TestPyPI then PyPI.
3. Smoke-test the wheel from PyPI in a fresh venv.
4. `gh release create v4.0.0rc2 --prerelease`.
5. If clean → bump to `4.0.0` final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)