### PR TITLE
fix: route seg-level validation errors through errh.seg_error

### DIFF
--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -33,14 +33,23 @@ if TYPE_CHECKING:
 
 def apply_segment_errors(node: segment_if, seg_data: pyx12.segment.Segment, errh: Any) -> bool:
     """Drive a segment validation: run is_valid_errors and forward errors
-    with cursor maintenance. Seg-level errors (too many elements, syntax)
-    leave map_node=None so they attach to the prior cursor; per-element
-    errors carry map_node from the leaf and trigger add_ele(map_node)
-    when the cursor changes."""
+    with cursor maintenance. Per-element errors carry map_node from the
+    leaf and trigger add_ele(map_node) when the cursor changes. Seg-level
+    errors (too many elements, too many sub-elements, syntax violations,
+    mandatory composite missing, composite-not-used) leave map_node=None;
+    they have no element to attach to, so they route through seg_error
+    with X12 IK3 code "8" ("segment has data element errors") — the only
+    IK3 code that semantically fits these data-element-level issues.
+    Their original IK4 codes ("3", "10", "1", "5", "2") collide with
+    different IK3 semantics and would produce wrong or dropped 999
+    output."""
     ok, errors = node.is_valid_errors(seg_data)
     prev_cursor = None
     for e in errors:
-        if e.map_node is not None and e.map_node is not prev_cursor:
+        if e.map_node is None:
+            errh.seg_error("8", e.err_str, e.err_val)
+            continue
+        if e.map_node is not prev_cursor:
             errh.add_ele(e.map_node)
             prev_cursor = e.map_node
         errh.ele_error(e.err_cde, e.err_str, e.err_val, e.refdes)

--- a/pyx12/test/test_error_handler.py
+++ b/pyx12/test/test_error_handler.py
@@ -38,6 +38,5 @@ class TestEleErrorBeforeAddEle(unittest.TestCase):
         self.assertTrue(eh.ele_node_added)
         self.assertEqual(len(eh.cur_seg_node.elements), 1)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 import pyx12.map_if
 import pyx12.params
@@ -758,7 +759,7 @@ class _RecordingErrh:
     """Captures errh.add_ele/ele_error/seg_error calls for assertions."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple] = []
+        self.calls: list[tuple[Any, ...]] = []
 
     def add_ele(self, map_node):
         self.calls.append(("add_ele", map_node))

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -752,3 +752,49 @@ class CompositeRequiredMissing(unittest.TestCase):
         result, errors = self.node.is_valid_errors(seg_data)
         self.assertFalse(result)
         self.assertEqual([e.err_cde for e in errors], ["1"])
+
+
+class _RecordingErrh:
+    """Captures errh.add_ele/ele_error/seg_error calls for assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def add_ele(self, map_node):
+        self.calls.append(("add_ele", map_node))
+
+    def ele_error(self, err_cde, err_str, err_val=None, refdes=None):
+        self.calls.append(("ele_error", err_cde, err_val, refdes))
+
+    def seg_error(self, err_cde, err_str, err_val=None, src_line=None):
+        self.calls.append(("seg_error", err_cde, err_val))
+
+
+class ApplySegmentErrorsRouting(unittest.TestCase):
+    """Regression for the 4.0.0rc2 AttributeError: seg-level errors with
+    map_node=None must route through errh.seg_error (IK3) rather than
+    errh.ele_error (IK4), since the latter dereferences cur_ele_node which
+    is None on the first error of a segment."""
+
+    def setUp(self):
+        from pyx12.map_if._segment import apply_segment_errors
+
+        self.apply = apply_segment_errors
+        param = pyx12.params.params()
+        self.map = pyx12.map_if.load_map_file("837.4010.X098.A1.xml", param)
+
+    def test_composite_not_used_routes_to_seg_error(self):
+        # REF segment with REF04 (a composite marked Not Used) supplied:
+        # _composite emits err_cde="5" with map_node=None. Without the
+        # upstream remap this would call errh.ele_error against a None
+        # cur_ele_node and crash with AttributeError (the production
+        # 4.0.0rc2 traceback). With the remap it must route to seg_error
+        # with code "8" — the only valid IK3 code that fits.
+        ref_node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/HEADER/REF")
+        seg_data = pyx12.segment.Segment("REF*87*004010X098A1**:1~", "~", "*", ":")
+        errh = _RecordingErrh()
+        ok = self.apply(ref_node, seg_data, errh)
+        self.assertFalse(ok)
+        self.assertIn(("seg_error", "8", None), errh.calls)
+        self.assertFalse(any(c[0] == "ele_error" for c in errh.calls))
+        self.assertFalse(any(c[0] == "add_ele" for c in errh.calls))


### PR DESCRIPTION
## Summary
- Fixes the 4.0.0rc2 production `AttributeError: 'NoneType' object has no attribute 'add_error'` raised from `error_handler.py:315` when `apply_segment_errors` forwards a seg-level validation error (no `map_node`) on a fresh `err_handler` whose `cur_ele_node` is still `None`.
- Routes `EleError` items with `map_node=None` through `errh.seg_error` instead of `errh.ele_error`, and remaps the IK4 code to IK3 `"8"` (`"Segment has data element errors"`) — the only IK3 code whose semantics fit all five emission sites:
  - `_segment.py:390` "Too many elements in segment" (`"3"`)
  - `_segment.py:413` "Too many sub-elements in composite" (`"3"`)
  - `_segment.py:459` syntax E / non-E violations (`"10"` / `"2"`)
  - `_composite.py:131` "Mandatory composite missing" (`"1"`)
  - `_composite.py:139` "Composite marked Not Used" (`"5"`)
- Naively passing the original code through `seg_error` would either produce wrong 999 output (IK3 `"3"` = "Required segment missing", not "Too many data elements") or be silently dropped (`"10"` is not in `valid_IK3_codes`).

## Why upstream and not in `error_handler.ele_error`
`f39e456` plugged the related `ele_node_added` `AttributeError`, but its regression test pre-seeded `cur_ele_node = MagicMock()`, so it never exercised the production path. A guard at the `ele_error` level would still pass the original IK4 code (`"3"`/`"10"`/etc.) into `seg_error`, where it is meaningless or filtered. The remap belongs in the producer (`apply_segment_errors`), where the IK4→IK3 translation is unambiguous.

## Trade-off
The IK4 code distinction collapses to a single IK3 `"8"` per segment. The error-string detail is preserved on `err_seg.errors` for logging; the 999 just signals "this segment has data element errors" rather than the specific element issue, which is the correct behavior when there is no element position to attach to.

## Test plan
- [x] New `ApplySegmentErrorsRouting` test in `pyx12/test/test_map_if.py` with a recording `errh` stub; uses the existing REF composite-not-used fixture (which hits `_composite.py:139` with `map_node=None`) and asserts `seg_error` is called with code `"8"` and that `ele_error` / `add_ele` are NOT called.
- [x] Drop `test_ele_error_with_no_ele_cursor_falls_through_to_seg` from `test_error_handler.py` — the fix is now upstream, so `ele_error` never sees `cur_ele_node=None` for this code path.
- [x] Full suite: 539 / 539 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)