### PR TITLE
release: 4.0.0rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyx12"
-version = "4.0.0rc2"
+version = "4.0.0rc3"
 description = "HIPAA X12 validator, parser and converter"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyx12/version.py
+++ b/pyx12/version.py
@@ -1,1 +1,1 @@
-__version__ = "4.0.0rc2"
+__version__ = "4.0.0rc3"


### PR DESCRIPTION
## Summary
- Bumps version to `4.0.0rc3` in [pyproject.toml](pyproject.toml) and [pyx12/version.py](pyx12/version.py).
- Picks up the `apply_segment_errors` seg-level routing fix from #161 on top of `4.0.0rc2`.

## Why a new RC
`4.0.0rc2` hit `AttributeError: 'NoneType' object has no attribute 'add_error'` in production traffic via the `swmbh-x12-sbus` worker. A fresh `err_handler` dispatched a seg-level `EleError` (`map_node=None`) through `ele_error`, which then dereferenced `cur_ele_node` (still `None`).

#161 routes those seg-level errors through `seg_error` with IK3 code `"8"` ("Segment has data element errors") instead — the only IK3 code whose semantics fit all five emission sites. The original IK4 codes (`"3"`/`"10"`/`"1"`/`"5"`/`"2"`) collide with different IK3 semantics or are not valid IK3 codes at all.

## Pre-flight (via `/publish dryrun`)
- [x] pytest: 539/539
- [x] mypy --strict: clean (83 files)
- [x] ruff check: clean
- [x] ruff format --check: clean
- [x] tools/check_maps.py: 32 maps clean
- [x] tools/test_install.py: post-packaging install clean

## Test plan
- [ ] CI green on this PR (4 Python builds + mypy strict + maps + post-packaging + docs).
- [ ] After merge: `/publish` cuts the `v4.0.0rc3` tag → release.yml → TestPyPI + PyPI → GitHub pre-release.
- [ ] Smoke `swmbh-x12-sbus` against `pyx12==4.0.0rc3` to confirm the seg-level routing fix resolves the rc2 traceback.
- [ ] If clean: promote to `4.0.0` final. If a new regression surfaces: fix PR → rc4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)