### PR TITLE
feat: wire errh_json through x12n_document + x12valid (issue #50)

### DIFF
--- a/pyx12/scripts/x12valid.py
+++ b/pyx12/scripts/x12valid.py
@@ -68,6 +68,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--quiet", "-q", action="store_true")
     parser.add_argument("--html", "-H", action="store_true")
     parser.add_argument(
+        "--json-output",
+        "-J",
+        action="store_true",
+        dest="json_output",
+        help="Write JSON error output alongside the input as <input>.json",
+    )
+    parser.add_argument(
         "--exclude-external-codes",
         "-x",
         action="append",
@@ -112,6 +119,7 @@ def main():
         logger.setLevel(logging.ERROR)
     fd_997 = None
     fd_html = None
+    fd_json = None
     flag_997 = True
     param.set("exclude_external_codes", ",".join(args.exclude_external))
     if args.map_path:
@@ -139,6 +147,12 @@ def main():
                     else:
                         target_html = src_filename + ".html"
                     fd_html = open(target_html, "w", encoding="utf-8")
+                if args.json_output:
+                    if os.path.splitext(src_filename)[1] == ".txt":
+                        target_json = os.path.splitext(src_filename)[0] + ".json"
+                    else:
+                        target_json = src_filename + ".json"
+                    fd_json = open(target_json, "w", encoding="utf-8")
 
                 logger.debug(f"Before x12n_document for {src_filename}")
                 if pyx12.x12n_document.x12n_document(
@@ -147,6 +161,7 @@ def main():
                     fd_997=fd_997,
                     fd_html=fd_html,
                     fd_xmldoc=None,
+                    fd_json=fd_json,
                     map_path=args.map_path,
                 ):
                     sys.stderr.write("%s: OK\n" % (src_filename))
@@ -166,6 +181,9 @@ def main():
                     fd_997.close()
                 if fd_html:
                     fd_html.close()
+                if fd_json:
+                    fd_json.close()
+                    fd_json = None
             except OSError:
                 logger.exception("Could not open files")
                 return False

--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 from io import StringIO
@@ -79,10 +80,27 @@ class X12DocumentTestCase(unittest.TestCase):
         fd_997.seek(0)
         self._isX12Diff(fd_997_base, fd_997)
 
+    def _test_json(self, datakey):
+        self.assertIn(datakey, datafiles)
+        self.assertIn("source", datafiles[datakey])
+        self.assertIn("resJson", datafiles[datakey])
+        fd_source = self._makeFd(datafiles[datakey]["source"])
+        fd_997 = StringIO()
+        fd_json = StringIO()
+        pyx12.x12n_document.x12n_document(
+            self.param, fd_source, fd_997, None, None, fd_json=fd_json
+        )
+        fd_json.seek(0)
+        actual = json.loads(fd_json.read())
+        self.assertEqual(actual, datafiles[datakey]["resJson"])
+
 
 class Test834(X12DocumentTestCase):
     def test_834_lui_id(self):
         self._test_997("834_lui_id")
+
+    def test_834_lui_id_json(self):
+        self._test_json("834_lui_id")
 
     def test_834_ls_le_ls(self):
         self._test_999("834_ls_le_ls")
@@ -110,6 +128,9 @@ class X12Structure(X12DocumentTestCase):
 
     def test_bad_2010AA_bug(self):
         self._test_997("bad_2010AA_bug")
+
+    def test_bad_2010AA_bug_json(self):
+        self._test_json("bad_2010AA_bug")
 
     def test_elements(self):
         self._test_997("elements")

--- a/pyx12/test/x12testdata.py
+++ b/pyx12/test/x12testdata.py
@@ -1,4 +1,6 @@
-datafiles = {
+from typing import Any
+
+datafiles: dict[str, dict[str, Any]] = {
     "834_lui_id": {
         "source": """ISA*00*          *00*          *ZZ*D00XXX         *ZZ*00AA           *070305*1832*U*00401*000701336*0*P*:~
 GS*BE*D00XXX*00AA*20070305*1832*13360001*X*004010X095A1~
@@ -36,6 +38,41 @@ SE*6*0001~
 GE*1*13360001~
 IEA*1*703201721~
 """,
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000701336",
+                    "ta1_req": "0",
+                    "orig_date": "070305",
+                    "orig_time": "1832",
+                    "cur_line": 24,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "13360001",
+                            "fic": "BE",
+                            "vriic": "004010X095A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 23,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "834",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 22,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "834_ls_le_ls": {
         "source": """ISA*00*          *00*          *ZZ*ORDHS          *ZZ*MB888880       *130312*0206*!*00501*000000238*0*P*:~
@@ -563,6 +600,58 @@ REF*6R*AKLKJ124231AD~
 SE*24*000000001~
 GE*1*56~
 IEA*1*000000288~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000000288",
+                    "ta1_req": "0",
+                    "orig_date": "040608",
+                    "orig_time": "1333",
+                    "cur_line": 28,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "56",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 27,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "000000001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 26,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 8,
+                                            "pos": 15,
+                                            "name": "Billing Provider Name",
+                                            "ls_id": None,
+                                            "cur_line": 10,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing Provider Name" (2010AA) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "elements": {
         "res997": """ISA*00*          *00*          *ZZ*RECEIVER       *ZZ*SENDER         *070320*0942*U*00401*703200942*0*P*:~

--- a/pyx12/x12n_document.py
+++ b/pyx12/x12n_document.py
@@ -19,6 +19,7 @@ import logging
 from collections.abc import Callable
 from typing import Any, TextIO
 
+import pyx12.errh_json
 import pyx12.error_997
 import pyx12.error_999
 
@@ -59,6 +60,7 @@ def x12n_document(
     fd_997: TextIO | None,
     fd_html: TextIO | None,
     fd_xmldoc: TextIO | None = None,
+    fd_json: TextIO | None = None,
     xslt_files: Any = None,
     map_path: str | None = None,
     callback: Callable[..., Any] | None = None,
@@ -74,6 +76,8 @@ def x12n_document(
     :type fd_html: file descriptor
     :param fd_xmldoc: XML output document
     :type fd_xmldoc: file descriptor
+    :param fd_json: JSON error output document
+    :type fd_json: file descriptor
     :rtype: boolean
     """
     logger = logging.getLogger("pyx12")
@@ -267,6 +271,14 @@ def x12n_document(
                 del visit_999
             except Exception:
                 logger.exception("Failed to create 999 response")
+
+    if fd_json:
+        try:
+            visit_json = pyx12.errh_json.errh_json_visitor(fd_json)
+            errh.accept(visit_json)
+            del visit_json
+        except Exception:
+            logger.exception("Failed to write JSON error output")
     src.close()
     try:
         if not valid or errh.get_error_count() > 0:


### PR DESCRIPTION
Slice #2 of [issue #50](https://github.com/azoner/pyx12/issues/50). Builds on the visitor from #163. After this slice the JSON error output is reachable end-to-end via the document orchestrator and CLI; subsequent slices backfill `resJson` across the rest of the fixture corpus, integrate the context-reader path, and address [issue #120](https://github.com/azoner/pyx12/issues/120) CTX enrichment.

## What this slice does

- `pyx12/x12n_document.py`: new `fd_json: TextIO | None = None` parameter. If set, runs `pyx12.errh_json.errh_json_visitor` against the `err_handler` tree after the existing 997/999 dispatch. Failure-tolerant — exception logged, doesn't break the orchestrator.
- `pyx12/scripts/x12valid.py`: new `-J` / `--json-output` flag. When set, opens `<input>.json` (or `<basename>.json` for `.txt` inputs) alongside the X12 input and passes the descriptor to `x12n_document`.
- `pyx12/test/x12testdata.py`: type annotation upgrade — `datafiles: dict[str, dict[str, Any]]` (mypy previously inferred `dict[str, dict[str, str]]`, which the new dict-valued `resJson` field would break). Two fixtures gain `resJson` entries:
  - `834_lui_id` — clean baseline (`ack_code=A` all the way down, empty errors arrays at every level)
  - `bad_2010AA_bug` — seg-level error code `"3"` on NM1 (`Mandatory loop "Billing Provider Name" (2010AA) missing`)
- `pyx12/test/test_x12n_document.py`: new `_test_json(datakey)` helper parallel to `_test_997` / `_test_999`. Wires up `Test834.test_834_lui_id_json` and `X12Structure.test_bad_2010AA_bug_json`.

## CLI usage

```
x12valid -J -- input.x12
# writes both input.x12.997 and input.x12.json
```

## Test plan

- [x] pytest pyx12/test/: 550 passed (548 baseline from #163 merge + 2 new JSON tests)
- [x] mypy --strict pyx12: clean (85 files)
- [x] ruff check + ruff format --check: clean
- [ ] Slice #3 (next PR) backfills `resJson` on the remaining ~25 fixtures with substantive errors
- [ ] Slice #4 wires the same JSON output through `pyx12/x12context.py` (X12ContextReader path)
- [ ] Slice #5 closes issue #120 by emitting CTX segments after AK2 / IK3 / IK4 in `error_999.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)