### PR TITLE
test: backfill resJson on remaining 22 fixtures (issue #50)

### DIFF
--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -105,26 +105,44 @@ class Test834(X12DocumentTestCase):
     def test_834_ls_le_ls(self):
         self._test_999("834_ls_le_ls")
 
+    def test_834_ls_le_ls_json(self):
+        self._test_json("834_ls_le_ls")
+
 
 class Test835(X12DocumentTestCase):
     def test_835id(self):
         self._test_997("835id")
+
+    def test_835id_json(self):
+        self._test_json("835id")
 
 
 class ExplicitMissing(X12DocumentTestCase):
     def test_837miss(self):
         self._test_997("837miss")
 
+    def test_837miss_json(self):
+        self._test_json("837miss")
+
 
 class X12Structure(X12DocumentTestCase):
     def test_mult_isa(self):
         self._test_997("mult_isa")
 
+    def test_mult_isa_json(self):
+        self._test_json("mult_isa")
+
     def test_trailer_errors(self):
         self._test_997("trailer_errors")
 
+    def test_trailer_errors_json(self):
+        self._test_json("trailer_errors")
+
     def test_trailing_terms(self):
         self._test_997("trailing_terms")
+
+    def test_trailing_terms_json(self):
+        self._test_json("trailing_terms")
 
     def test_bad_2010AA_bug(self):
         self._test_997("bad_2010AA_bug")
@@ -135,49 +153,94 @@ class X12Structure(X12DocumentTestCase):
     def test_elements(self):
         self._test_997("elements")
 
+    def test_elements_json(self):
+        self._test_json("elements")
+
     def test_bad_header_looping(self):
         self._test_997("bad_header_looping")
+
+    def test_bad_header_looping_json(self):
+        self._test_json("bad_header_looping")
 
     def test_blank1(self):
         self._test_997("blank1")
 
+    def test_blank1_json(self):
+        self._test_json("blank1")
+
     def test_ele(self):
         self._test_997("ele")
+
+    def test_ele_json(self):
+        self._test_json("ele")
 
     def test_fail_no_IEA(self):
         self._test_997("fail_no_IEA")
 
+    def test_fail_no_IEA_json(self):
+        self._test_json("fail_no_IEA")
+
     def test_loop_counting(self):
         self._test_997("loop_counting")
+
+    def test_loop_counting_json(self):
+        self._test_json("loop_counting")
 
     def test_loop_counting2(self):
         self._test_997("loop_counting2")
 
+    def test_loop_counting2_json(self):
+        self._test_json("loop_counting2")
+
     def test_multiple_trn(self):
         self._test_997("multiple_trn")
+
+    def test_multiple_trn_json(self):
+        self._test_json("multiple_trn")
 
     def test_ordinal(self):
         self._test_997("ordinal")
 
+    def test_ordinal_json(self):
+        self._test_json("ordinal")
+
     def test_per_segment_repeat(self):
         self._test_997("per_segment_repeat")
+
+    def test_per_segment_repeat_json(self):
+        self._test_json("per_segment_repeat")
 
     def test_repeat_init_segment(self):
         self._test_997("repeat_init_segment")
 
+    def test_repeat_init_segment_json(self):
+        self._test_json("repeat_init_segment")
+
     def test_simple1(self):
         self._test_997("simple1")
 
+    def test_simple1_json(self):
+        self._test_json("simple1")
+
     def test_simple_837p(self):
         self._test_997("simple_837p")
+
+    def test_simple_837p_json(self):
+        self._test_json("simple_837p")
 
 
 class Test5010(X12DocumentTestCase):
     def test_834_lui_id_5010(self):
         self._test_999("834_lui_id_5010")
 
+    def test_834_lui_id_5010_json(self):
+        self._test_json("834_lui_id_5010")
+
     def test_834_eol_in_element(self):
         self._test_999("834_eol_in_element")
+
+    def test_834_eol_in_element_json(self):
+        self._test_json("834_eol_in_element")
 
 
 class TestTemp(X12DocumentTestCase):

--- a/pyx12/test/x12testdata.py
+++ b/pyx12/test/x12testdata.py
@@ -165,6 +165,41 @@ SE*6*0001~
 GE*1*146~
 IEA*1*000000238~
 """,
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000000238",
+                    "ta1_req": "0",
+                    "orig_date": "130312",
+                    "orig_time": "0206",
+                    "cur_line": 78,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "146",
+                            "fic": "BE",
+                            "vriic": "005010X220A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 77,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "834",
+                                    "trn_set_control_num": "146001",
+                                    "vriic": "005010X220A1",
+                                    "ack_code": "A",
+                                    "cur_line": 76,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "835id": {
         "res997": """ISA*00*          *00*          *ZZ*382999999      *ZZ*383319999      *090304*1036*U*00401*903041036*1*P*:~
@@ -217,6 +252,41 @@ SE*33*40731~
 GE*1*3444~
 IEA*1*000003447~
 """,
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000003447",
+                    "ta1_req": "1",
+                    "orig_date": "090220",
+                    "orig_time": "1816",
+                    "cur_line": 37,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "3444",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 36,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "40731",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 35,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "837miss": {
         "res997": """ISA*00*          *00*          *ZZ*ZZ001          *ZZ*ZZ000          *041211*1902*U*00401*412111902*1*T*:~
@@ -234,6 +304,56 @@ IEA*1*412111902~
         "source": """ISA*00*          *00*          *ZZ*ZZ000          *ZZ*ZZ001          *030828*1128*U*00401*000010121*1*T*:~
 GS*HC*ZZ000*ZZ001*20030828*1128*17*X*004010X098A1~
 ST*837*11280001~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000010121",
+                    "ta1_req": "1",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 1,
+                    "errors": [
+                        {
+                            "err_cde": "023",
+                            "err_str": 'Mandatory segment "Interchange Control Trailer" (IEA=000010121) missing',
+                        }
+                    ],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 0,
+                            "st_count_recv": 0,
+                            "cur_line": 2,
+                            "errors": [
+                                {
+                                    "err_cde": "3",
+                                    "err_str": 'Mandatory segment "Functional Group Trailer" (GE=17) missing',
+                                }
+                            ],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 3,
+                                    "errors": [
+                                        {
+                                            "err_cde": "2",
+                                            "err_str": 'Mandatory segment "Transaction Set Trailer" (SE=11280001) missing',
+                                        }
+                                    ],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "mult_isa": {
         "res997": """ISA*00*          *00*          *ZZ*ZZ001          *ZZ*ZZ000          *070328*1628*U*00401*703281628*0*T*:~
@@ -366,6 +486,534 @@ ST*835*0001~
 SE*2*0001~
 GE*1*383880001~
 IEA*3*000010121~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000010125",
+                    "ta1_req": "0",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 30,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HI",
+                            "vriic": "004010X094A1",
+                            "ack_code": "R",
+                            "st_count_orig": 3,
+                            "st_count_recv": 3,
+                            "cur_line": 12,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 5,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 5,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280002",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 8,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 8,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280003",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 11,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 11,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "gs_control_num": "18",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 17,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 16,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "REF",
+                                            "seg_count": 2,
+                                            "pos": 15,
+                                            "name": "Transmission Type Identification",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory segment "Transmission Type Identification" (REF) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Submitter Name",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Submitter Name" (1000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Receiver Name",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Receiver Name" (1000B) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 1,
+                                            "name": "Billing/Pay-To Provider Hierarchical Level",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing/Pay-To Provider Hierarchical Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "gs_control_num": "383880001",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 21,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 20,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BPR",
+                                            "seg_count": 1,
+                                            "pos": 20,
+                                            "name": "Financial Information",
+                                            "ls_id": None,
+                                            "cur_line": 20,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "gs_control_num": "2",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 25,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 24,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BPR",
+                                            "seg_count": 1,
+                                            "pos": 20,
+                                            "name": "Financial Information",
+                                            "ls_id": None,
+                                            "cur_line": 24,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "gs_control_num": "3",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 29,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 28,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BPR",
+                                            "seg_count": 1,
+                                            "pos": 20,
+                                            "name": "Financial Information",
+                                            "ls_id": None,
+                                            "cur_line": 28,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "isa_trn_set_id": "000010121",
+                    "ta1_req": "0",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 52,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HI",
+                            "vriic": "004010X094A1",
+                            "ack_code": "R",
+                            "st_count_orig": 3,
+                            "st_count_recv": 3,
+                            "cur_line": 42,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 35,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 35,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280002",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 38,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 38,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280003",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 41,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 41,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "gs_control_num": "18",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 47,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 46,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "REF",
+                                            "seg_count": 2,
+                                            "pos": 15,
+                                            "name": "Transmission Type Identification",
+                                            "ls_id": None,
+                                            "cur_line": 46,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory segment "Transmission Type Identification" (REF) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Submitter Name",
+                                            "ls_id": None,
+                                            "cur_line": 46,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Submitter Name" (1000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Receiver Name",
+                                            "ls_id": None,
+                                            "cur_line": 46,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Receiver Name" (1000B) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 1,
+                                            "name": "Billing/Pay-To Provider Hierarchical Level",
+                                            "ls_id": None,
+                                            "cur_line": 46,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing/Pay-To Provider Hierarchical Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "gs_control_num": "383880001",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 51,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 50,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BPR",
+                                            "seg_count": 1,
+                                            "pos": 20,
+                                            "name": "Financial Information",
+                                            "ls_id": None,
+                                            "cur_line": 50,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
+                },
+            ]
+        },
     },
     "trailer_errors": {
         "res997": """ISA*00*          *00*          *ZZ*ENCOUNTER      *ZZ*00HP           *041206*1224*U*00401*412061224*0*P*:~
@@ -503,6 +1151,60 @@ DTP*573*D8*20040719~
 SE*59*300207437~
 GE*2*333~
 IEA*5*333~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484950",
+                    "ta1_req": "1",
+                    "orig_date": "040820",
+                    "orig_time": "1133",
+                    "cur_line": 122,
+                    "errors": [
+                        {"err_cde": "001", "err_str": "IEA id=333 does not match ISA id=000484950"},
+                        {"err_cde": "021", "err_str": "IEA count for IEA02=333 is wrong"},
+                    ],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "R",
+                            "st_count_orig": 2,
+                            "st_count_recv": 2,
+                            "cur_line": 121,
+                            "errors": [
+                                {"err_cde": "4", "err_str": "GE id=333 does not match GS id=1"}
+                            ],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300207436",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 61,
+                                    "errors": [
+                                        {
+                                            "err_cde": "4",
+                                            "err_str": "SE count of 60 for SE02=300207436 is wrong. I count 59",
+                                        }
+                                    ],
+                                    "segments": [],
+                                },
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300207437",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 120,
+                                    "errors": [],
+                                    "segments": [],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "trailing_terms": {
         "res997": """ISA*00*          *00*          *ZZ*0000BBB        *ZZ*00000AAA       *070319*1742*U*00401*703191742*0*P*:~
@@ -559,6 +1261,73 @@ DTP*472*RD8*20031213-20031218~
 SE*38*300145997~
 GE*1*1~
 IEA*1*000484889~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484889",
+                    "ta1_req": "0",
+                    "orig_date": "040709",
+                    "orig_time": "1439",
+                    "cur_line": 42,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 41,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300145997",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 40,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "CLM",
+                                            "seg_count": 22,
+                                            "pos": 130,
+                                            "name": "Claim Information",
+                                            "ls_id": None,
+                                            "cur_line": 24,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "SEG1",
+                                                    "err_str": "Segment contains trailing element terminators",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 18,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "1073",
+                                                    "name": "Explanation of Benefits Indicator",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "1",
+                                                            "err_str": 'Mandatory data element "Explanation of Benefits Indicator" (CLM18) is missing',
+                                                            "err_val": None,
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "bad_2010AA_bug": {
         "res997": """ISA*00*          *00*          *ZZ*RECEIVER       *ZZ*SENDER         *040701*1620*U*00401*407011620*0*P*:~
@@ -711,6 +1480,216 @@ REF*6R*AKLKJ124231AD~
 SE*30*000000001~
 GE*1*56~
 IEA*1*000000288~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000000288",
+                    "ta1_req": "0",
+                    "orig_date": "040608",
+                    "orig_time": "1333",
+                    "cur_line": 33,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "56",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 32,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "000000001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 31,
+                                    "errors": [
+                                        {
+                                            "err_cde": "4",
+                                            "err_str": "SE count of 30 for SE02=000000001 is wrong. I count 29",
+                                        }
+                                    ],
+                                    "segments": [
+                                        {
+                                            "seg_id": "REF",
+                                            "seg_count": 3,
+                                            "pos": 15,
+                                            "name": "Transmission Type Identification",
+                                            "ls_id": None,
+                                            "cur_line": 5,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 2,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "127",
+                                                    "name": "Transmission Type Code",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(004010X098A2) is not a valid code for Transmission Type Code (REF02)",
+                                                            "err_val": "004010X098A2",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "PER",
+                                            "seg_count": 5,
+                                            "pos": 45,
+                                            "name": "Submitter EDI Contact Information",
+                                            "ls_id": None,
+                                            "cur_line": 7,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 3,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "365",
+                                                    "name": "Communication Number Qualifier",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(TA) is not a valid code for Communication Number Qualifier (PER03)",
+                                                            "err_val": "TA",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 7,
+                                            "pos": 20,
+                                            "name": "Receiver Name",
+                                            "ls_id": None,
+                                            "cur_line": 9,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 8,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "66",
+                                                    "name": "Identification Code Qualifier",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(47) is not a valid code for Identification Code Qualifier (NM108)",
+                                                            "err_val": "47",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 15,
+                                            "pos": 15,
+                                            "name": "Subscriber Name",
+                                            "ls_id": None,
+                                            "cur_line": 17,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 8,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "66",
+                                                    "name": "Identification Code Qualifier",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "5",
+                                                            "err_str": 'Data element "Identification Code Qualifier" (NM108) is too long: len("MIM") = 3 > 2 (max_len)',
+                                                            "err_val": "MIM",
+                                                        },
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(MIM) is not a valid code for Identification Code Qualifier (NM108)",
+                                                            "err_val": "MIM",
+                                                        },
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "DMG",
+                                            "seg_count": 18,
+                                            "pos": 32,
+                                            "name": "Subscriber Demographic Information",
+                                            "ls_id": None,
+                                            "cur_line": 20,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 2,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "1251",
+                                                    "name": "Subscriber Birth Date",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "8",
+                                                            "err_str": 'Data element "Subscriber Birth Date" (DMG02) contains an invalid date (19461301)',
+                                                            "err_val": "19461301",
+                                                        }
+                                                    ],
+                                                },
+                                                {
+                                                    "ele_pos": 3,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "1068",
+                                                    "name": "Subscriber Gender Code",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(R) is not a valid code for Subscriber Gender Code (DMG03)",
+                                                            "err_val": "R",
+                                                        }
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "CLM",
+                                            "seg_count": 23,
+                                            "pos": 130,
+                                            "name": "Claim Information",
+                                            "ls_id": None,
+                                            "cur_line": 25,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 5,
+                                                    "subele_pos": 1,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "1331",
+                                                    "name": "Facility Type Code",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(95) is not a valid code for Facility Type Code (CLM05-01)",
+                                                            "err_val": "95",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "bad_header_looping": {
         "res997": """ISA*00*          *00*          *ZZ*00AA           *ZZ*D00000         *070405*0014*U*00401*704050014*0*P*:~
@@ -805,6 +1784,136 @@ LQ*HE*N14~
 SE*39*0001~
 GE*1*383880001~
 IEA*1*000238388~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000238388",
+                    "ta1_req": "0",
+                    "orig_date": "041028",
+                    "orig_time": "1609",
+                    "cur_line": 76,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "383880001",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 75,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 74,
+                                    "errors": [
+                                        {
+                                            "err_cde": "4",
+                                            "err_str": "SE count of 39 for SE02=0001 is wrong. I count 72",
+                                        }
+                                    ],
+                                    "segments": [
+                                        {
+                                            "seg_id": "DTM",
+                                            "seg_count": 5,
+                                            "pos": 70,
+                                            "name": "Production Date",
+                                            "ls_id": None,
+                                            "cur_line": 7,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 2,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "373",
+                                                    "name": "Production Date",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "8",
+                                                            "err_str": 'Data element "Production Date" (DTM02) contains an invalid date (11111111)',
+                                                            "err_val": "11111111",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "N1",
+                                            "seg_count": 39,
+                                            "pos": 130,
+                                            "name": "Health Care Remark Codes",
+                                            "ls_id": None,
+                                            "cur_line": 41,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "1",
+                                                    "err_str": "Segment N1*PR not found.  Started at /ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000/2100/2110/LQ",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "N3",
+                                            "seg_count": 40,
+                                            "pos": 130,
+                                            "name": "Health Care Remark Codes",
+                                            "ls_id": None,
+                                            "cur_line": 42,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "1",
+                                                    "err_str": "Segment N3*P.O. BOX 30479 not found.  Started at /ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000/2100/2110/LQ",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "N4",
+                                            "seg_count": 41,
+                                            "pos": 130,
+                                            "name": "Health Care Remark Codes",
+                                            "ls_id": None,
+                                            "cur_line": 43,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "1",
+                                                    "err_str": "Segment N4*LANSING not found.  Started at /ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000/2100/2110/LQ",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "N1",
+                                            "seg_count": 42,
+                                            "pos": 130,
+                                            "name": "Health Care Remark Codes",
+                                            "ls_id": None,
+                                            "cur_line": 44,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "1",
+                                                    "err_str": "Segment N1*PE not found.  Started at /ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000/2100/2110/LQ",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "blank1": {
         "res997": """ISA*00*          *00*          *ZZ*0000BBB        *ZZ*00000AAA       *050721*1643*U*00401*507211643*0*P*:~
@@ -890,6 +1999,120 @@ DTP*573*D8*20040210~
 SE*63*300145997~
 GE*1*1~
 IEA*1*000484889~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484889",
+                    "ta1_req": "0",
+                    "orig_date": "040709",
+                    "orig_time": "1439",
+                    "cur_line": 67,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 66,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300145997",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 65,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "SV2",
+                                            "seg_count": 57,
+                                            "pos": 375,
+                                            "name": "Institutional Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 59,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 2,
+                                                    "subele_pos": 1,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "235",
+                                                    "name": "Product or Service ID Qualifier",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(  ) is not a valid code for Product or Service ID Qualifier (SV202-01)",
+                                                            "err_val": "  ",
+                                                        }
+                                                    ],
+                                                },
+                                                {
+                                                    "ele_pos": 2,
+                                                    "subele_pos": 2,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "234",
+                                                    "name": "Procedure Code",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "1",
+                                                            "err_str": 'Mandatory data element "Procedure Code" (SV202-02) is missing',
+                                                            "err_val": None,
+                                                        }
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        {
+                                            "seg_id": "SVD",
+                                            "seg_count": 59,
+                                            "pos": 540,
+                                            "name": "Service Line Adjudication Information",
+                                            "ls_id": None,
+                                            "cur_line": 61,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 3,
+                                                    "subele_pos": 1,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "235",
+                                                    "name": "Product or Service ID Qualifier",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "7",
+                                                            "err_str": "(  ) is not a valid code for Product or Service ID Qualifier (SVD03-01)",
+                                                            "err_val": "  ",
+                                                        }
+                                                    ],
+                                                },
+                                                {
+                                                    "ele_pos": 3,
+                                                    "subele_pos": 2,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "234",
+                                                    "name": "Procedure Code",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "1",
+                                                            "err_str": 'Mandatory data element "Procedure Code" (SVD03-02) is missing',
+                                                            "err_val": None,
+                                                        }
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "ele": {
         "res997": """ISA*00*          *00*          *ZZ*0000BBB        *ZZ*00000AAA       *041214*1129*U*00401*412141129*1*P*:~
@@ -970,6 +2193,46 @@ DTP*573*D8*20040210~
 SE*63*300145997~
 GE*1*1~
 IEA*1*000484889~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484889",
+                    "ta1_req": "1",
+                    "orig_date": "040709",
+                    "orig_time": "3339",
+                    "cur_line": 67,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 66,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300145997 ",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 65,
+                                    "errors": [
+                                        {
+                                            "err_cde": "3",
+                                            "err_str": "SE id=300145997 does not match ST id=300145997 ",
+                                        }
+                                    ],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "fail_no_IEA": {
         "res997": """ISA*00*          *00*          *ZZ*ZZ001          *ZZ*ZZ000          *040701*1621*U*00401*407011621*0*T*:~
@@ -990,6 +2253,84 @@ GS*HC*ZZ000*ZZ001*20030828*1128*17*X*004010X098A1~
 ST*837*11280001~
 SE*0*11280001~
 GE*1*17~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000010121",
+                    "ta1_req": "1",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 1,
+                    "errors": [
+                        {
+                            "err_cde": "023",
+                            "err_str": 'Mandatory segment "Interchange Control Trailer" (IEA=000010121) missing',
+                        }
+                    ],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 5,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 4,
+                                    "errors": [
+                                        {
+                                            "err_cde": "4",
+                                            "err_str": "SE count of 0 for SE02=11280001 is wrong. I count 2",
+                                        }
+                                    ],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BHT",
+                                            "seg_count": 1,
+                                            "pos": 10,
+                                            "name": "Beginning of Hierarchical Transaction",
+                                            "ls_id": None,
+                                            "cur_line": 4,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 1,
+                                            "pos": 1,
+                                            "name": "Billing/Pay-To Provider Hierarchical Level",
+                                            "ls_id": None,
+                                            "cur_line": 4,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing/Pay-To Provider Hierarchical Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "loop_counting": {
         "res997": """ISA*00*          *00*          *ZZ*BBBBBBBBB      *ZZ*AAAAAAAA       *041210*0057*U*00401*412100057*1*P*:~
@@ -1424,6 +2765,106 @@ DTP*573*D8*20040929~
 SE*413*1179~
 GE*1*1167~
 IEA*1*000001168~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000001168",
+                    "ta1_req": "1",
+                    "orig_date": "041105",
+                    "orig_time": "1526",
+                    "cur_line": 417,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1167",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 416,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "1179",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 415,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 385,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 387,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 51, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 392,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 394,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 52, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 399,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 401,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 53, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 406,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 408,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 54, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "loop_counting2": {
         "res997": """ISA*00*          *00*          *ZZ*BBBBBBBBB      *ZZ*AAAAAAAA       *120718*1046*U*00401*207181046*1*P*:~
@@ -1858,6 +3299,106 @@ DTP*573*D8*20040929~
 SE*413*1179~
 GE*1*1167~
 IEA*1*000001168~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000001168",
+                    "ta1_req": "1",
+                    "orig_date": "041105",
+                    "orig_time": "1526",
+                    "cur_line": 417,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1167",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 416,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "1179",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 415,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 385,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 387,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 51, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 392,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 394,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 52, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 399,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 401,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 53, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "LX",
+                                            "seg_count": 406,
+                                            "pos": 365,
+                                            "name": "Service Line",
+                                            "ls_id": None,
+                                            "cur_line": 408,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "4",
+                                                    "err_str": "Loop 2400 exceeded max count.  Found 54, should have 50",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "multiple_trn": {
         "res997": """ISA*00*          *00*          *ZZ*ZZ001          *ZZ*ZZ000          *050807*0207*U*00401*508070207*0*T*:~
@@ -1916,6 +3457,234 @@ ST*835*0001~
 SE*2*0001~
 GE*1*383880001~
 IEA*3*000010121~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000010121",
+                    "ta1_req": "0",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 22,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HI",
+                            "vriic": "004010X094A1",
+                            "ack_code": "R",
+                            "st_count_orig": 3,
+                            "st_count_recv": 3,
+                            "cur_line": 12,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 5,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 5,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280002",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 8,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 8,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "trn_set_id": "278",
+                                    "trn_set_control_num": "11280003",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 11,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 10,
+                                            "name": "Utilization Management Organization (UMO) Level",
+                                            "ls_id": None,
+                                            "cur_line": 11,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Utilization Management Organization (UMO) Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "gs_control_num": "18",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 17,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 16,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "REF",
+                                            "seg_count": 2,
+                                            "pos": 15,
+                                            "name": "Transmission Type Identification",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory segment "Transmission Type Identification" (REF) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Submitter Name",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Submitter Name" (1000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "NM1",
+                                            "seg_count": 2,
+                                            "pos": 20,
+                                            "name": "Receiver Name",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Receiver Name" (1000B) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 2,
+                                            "pos": 1,
+                                            "name": "Billing/Pay-To Provider Hierarchical Level",
+                                            "ls_id": None,
+                                            "cur_line": 16,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing/Pay-To Provider Hierarchical Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "gs_control_num": "383880001",
+                            "fic": "HP",
+                            "vriic": "004010X091A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 21,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "835",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 20,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BPR",
+                                            "seg_count": 1,
+                                            "pos": 20,
+                                            "name": "Financial Information",
+                                            "ls_id": None,
+                                            "cur_line": 20,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ]
+        },
     },
     "ordinal": {
         "res997": """ISA*00*          *00*          *ZZ*0000BBB        *ZZ*00000AAA       *040809*1625*U*00401*408091625*0*P*:~
@@ -1995,6 +3764,41 @@ DTP*573*D8*20040210~
 SE*63*300145997~
 GE*1*1~
 IEA*1*000484889~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484889",
+                    "ta1_req": "0",
+                    "orig_date": "040709",
+                    "orig_time": "1439",
+                    "cur_line": 67,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 66,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300145997",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 65,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "per_segment_repeat": {
         "res997": """ISA*00*          *00*          *ZZ*RECEIVER       *ZZ*SENDER         *041210*0107*U*00401*412100107*0*P*:~
@@ -2042,6 +3846,58 @@ REF*6R*AKLKJ124231AD~
 SE*30*000000001~
 GE*1*56~
 IEA*1*000000288~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000000288",
+                    "ta1_req": "0",
+                    "orig_date": "040608",
+                    "orig_time": "1333",
+                    "cur_line": 34,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "56",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 33,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "000000001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 32,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "PER",
+                                            "seg_count": 7,
+                                            "pos": 45,
+                                            "name": "Submitter EDI Contact Information",
+                                            "ls_id": None,
+                                            "cur_line": 9,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "5",
+                                                    "err_str": "Segment PER exceeded max count.  Found 3, should have 2",
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "repeat_init_segment": {
         "res997": """ISA*00*          *00*          *ZZ*111111960      *ZZ*111111536      *070829*1105*U*00401*708291105*0*T*:~
@@ -2073,6 +3929,41 @@ EQ*30**CHD~
 SE*15*0001~
 GE*1*1~
 IEA*1*000168037~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000168037",
+                    "ta1_req": "0",
+                    "orig_date": "000816",
+                    "orig_time": "2105",
+                    "cur_line": 19,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HS",
+                            "vriic": "004010X092A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 18,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "270",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 17,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "simple1": {
         "res997": """ISA*00*          *00*          *ZZ*ZZ001          *ZZ*ZZ000          *040701*1611*U*00401*407011611*0*T*:~
@@ -2093,6 +3984,74 @@ ST*837*11280001~
 SE*2*11280001~
 GE*1*17~
 IEA*1*000010121~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000010121",
+                    "ta1_req": "0",
+                    "orig_date": "030828",
+                    "orig_time": "1128",
+                    "cur_line": 6,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "17",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 5,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "11280001",
+                                    "vriic": None,
+                                    "ack_code": "R",
+                                    "cur_line": 4,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "BHT",
+                                            "seg_count": 1,
+                                            "pos": 10,
+                                            "name": "Beginning of Hierarchical Transaction",
+                                            "ls_id": None,
+                                            "cur_line": 4,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Table 1 - Header" (HEADER) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                        {
+                                            "seg_id": "HL",
+                                            "seg_count": 1,
+                                            "pos": 1,
+                                            "name": "Billing/Pay-To Provider Hierarchical Level",
+                                            "ls_id": None,
+                                            "cur_line": 4,
+                                            "errors": [
+                                                {
+                                                    "err_cde": "3",
+                                                    "err_str": 'Mandatory loop "Billing/Pay-To Provider Hierarchical Level" (2000A) missing',
+                                                    "err_val": None,
+                                                }
+                                            ],
+                                            "elements": [],
+                                        },
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "simple_837p": {
         "res997": """ISA*00*          *00*          *ZZ*BBBBBBBBB      *ZZ*AAAAAAAA       *081117*1543*U*00401*811171543*1*P*:~
@@ -2173,6 +4132,41 @@ REF*6R*105797~
 SE*63*1179~
 GE*1*1167~
 IEA*1*000001168~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000001168",
+                    "ta1_req": "1",
+                    "orig_date": "041105",
+                    "orig_time": "1526",
+                    "cur_line": 67,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1167",
+                            "fic": "HC",
+                            "vriic": "004010X098A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 66,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "1179",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 65,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "simple_837i": {
         "source": """ISA*00*          *00*          *ZZ*00000AAA       *ZZ*0000BBB        *040709*1439*U*00401*000484889*0*P*:~
@@ -2310,7 +4304,42 @@ SVD*13256235*0**0100*5~
 DTP*573*D8*20040210~
 SE*132*300145997~
 GE*1*1~
-IEA*1*000484889~"""
+IEA*1*000484889~""",
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000484889",
+                    "ta1_req": "0",
+                    "orig_date": "040709",
+                    "orig_time": "1439",
+                    "cur_line": 136,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "1",
+                            "fic": "HC",
+                            "vriic": "004010X096A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 135,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "837",
+                                    "trn_set_control_num": "300145997",
+                                    "vriic": None,
+                                    "ack_code": "A",
+                                    "cur_line": 134,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "834_lui_id_5010": {
         "source": """ISA*00*          *00*          *ZZ*D00XXX         *ZZ*00AA           *070305*1832*U*00501*000701336*0*P*:~
@@ -2349,6 +4378,41 @@ SE*6*0001~
 GE*1*13360001~
 IEA*1*703201721~
 """,
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000701336",
+                    "ta1_req": "0",
+                    "orig_date": "070305",
+                    "orig_time": "1832",
+                    "cur_line": 24,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "13360001",
+                            "fic": "BE",
+                            "vriic": "005010X220A1",
+                            "ack_code": "A",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 23,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "834",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": "005010X220A1",
+                                    "ack_code": "A",
+                                    "cur_line": 22,
+                                    "errors": [],
+                                    "segments": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
     "834_eol_in_element": {
         "source": """ISA*00*          *00*          *ZZ*D00XXX         *ZZ*00AA           *070305*1832*U*00501*000701336*0*P*:~
@@ -2390,6 +4454,67 @@ SE*8*0001~
 GE*1*608852007~
 IEA*1*311071503~
 """,
+        "resJson": {
+            "interchanges": [
+                {
+                    "isa_trn_set_id": "000701336",
+                    "ta1_req": "0",
+                    "orig_date": "070305",
+                    "orig_time": "1832",
+                    "cur_line": 24,
+                    "errors": [],
+                    "groups": [
+                        {
+                            "gs_control_num": "13360001",
+                            "fic": "BE",
+                            "vriic": "005010X220A1",
+                            "ack_code": "R",
+                            "st_count_orig": 1,
+                            "st_count_recv": 1,
+                            "cur_line": 23,
+                            "errors": [],
+                            "transactions": [
+                                {
+                                    "trn_set_id": "834",
+                                    "trn_set_control_num": "0001",
+                                    "vriic": "005010X220A1",
+                                    "ack_code": "R",
+                                    "cur_line": 22,
+                                    "errors": [],
+                                    "segments": [
+                                        {
+                                            "seg_id": "N3",
+                                            "seg_count": 12,
+                                            "pos": 500,
+                                            "name": "Member Residence Street Address",
+                                            "ls_id": None,
+                                            "cur_line": 14,
+                                            "errors": [],
+                                            "elements": [
+                                                {
+                                                    "ele_pos": 1,
+                                                    "subele_pos": None,
+                                                    "repeat_pos": None,
+                                                    "ele_ref_num": "166",
+                                                    "name": "Member Address Line",
+                                                    "errors": [
+                                                        {
+                                                            "err_cde": "6",
+                                                            "err_str": 'Data element "Member Address Line" (N301), contains an invalid control character(<LF>)',
+                                                            "err_val": "<LF>",
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
     },
 }
 


### PR DESCRIPTION
Slice #3 of [issue #50](https://github.com/azoner/pyx12/issues/50). Mechanical, large diff but pure data.

## What this slice does

Backfills `resJson` on every fixture in `pyx12/test/x12testdata.py` that has a `source` but lacked `resJson`, then wires up matching `test_<key>_json` regression tests.

## How

Generated each `resJson` programmatically by driving the source through `x12n_document` with `fd_json=StringIO()`, then converted the JSON output to a Python dict literal (with `null`/`true`/`false` → `None`/`True`/`False`) and inserted it into the fixture entry. The whole file was then run through `ruff format` to normalize indentation.

The generator was a one-shot helper (`tools/backfill_resjson.py`) — deleted in this commit, since re-running it against the now-complete file would be a no-op.

## Coverage

- **22 fixtures backfilled** with `resJson` (`834_lui_id` and `bad_2010AA_bug` were already done in PR #164)
- **21 new `test_<key>_json` methods** added to `test_x12n_document.py` paralleling the existing `_test_997` / `_test_999` coverage. Skipped `simple_837i` because it lacks any current 997/999 regression test; its `resJson` stays in the data file for a future test.
- Largest single fixture: `mult_isa` at 527 lines of resJson (multiple ISA loops with errors at every level)

## Test plan

- [x] pytest pyx12/test/: 571 passed (550 baseline from #164 merge + 21 new JSON tests)
- [x] mypy --strict pyx12: clean (85 files)
- [x] ruff check + ruff format --check: clean
- [x] All new JSON tests pass against the same x12n_document path that emits the JSON — confirms round-trip stability

## What this does NOT do

- Does not address [issue #120](https://github.com/azoner/pyx12/issues/120) (CTX enrichment in `error_999.py` IK3/IK4) — that's slice #5
- Does not wire JSON output through `pyx12/x12context.py` — that's slice #4
- Does not modify the `errh_json_visitor` itself — slice #1 (#163) defined it; slice #2 (#164) wired it through `x12n_document`; this slice only adds fixture coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)