### PR TITLE
feat: thread err_handler tree through X12ContextReader (issue #50)

### DIFF
--- a/pyx12/test/test_x12context.py
+++ b/pyx12/test/test_x12context.py
@@ -1,6 +1,9 @@
+import json
 import unittest
 from io import StringIO
+from typing import Any
 
+import pyx12.errh_json
 import pyx12.error_handler
 import pyx12.params
 import pyx12.x12context
@@ -589,3 +592,53 @@ class TreeCopy(X12fileTestCase):
                     self.assertFalse(svc is new_svc)
                     self.assertNotEqual(svc.get_value("SVC01"), new_svc.get_value("SVC01"))
                     break
+
+
+class JsonErrorOutput(X12fileTestCase):
+    """X12ContextReader populates a passed-in err_handler tree as it
+    iterates segments. After iteration, the tree is walkable by
+    errh_json_visitor, producing the same JSON document as the
+    x12n_document orchestrator path.
+
+    The historical X12ContextReader silently discarded the `errh`
+    parameter and hardcoded `errh_list()` (a flat list, not walkable by
+    a visitor); the slice-#4 refactor threads the parameter through and
+    lifecycle-populates the tree alongside the existing per-data-node
+    errh_list flow."""
+
+    def _json_via_context_reader(self, datakey: str) -> dict[str, Any]:
+        fd = self._makeFd(datafiles[datakey]["source"])
+        errh = pyx12.error_handler.err_handler()
+        src = pyx12.x12context.X12ContextReader(self.param, errh, fd)
+        for _datatree in src.iter_segments():
+            pass
+        out = StringIO()
+        errh.accept(pyx12.errh_json.errh_json_visitor(out))
+        out.seek(0)
+        result: dict[str, Any] = json.loads(out.read())
+        return result
+
+    def test_834_lui_id_matches_x12n_document_resJson(self):
+        # Clean fixture (no validation errors). X12ContextReader's tree
+        # should match the resJson written by x12n_document.
+        actual = self._json_via_context_reader("834_lui_id")
+        self.assertEqual(actual, datafiles["834_lui_id"]["resJson"])
+
+    def test_bad_2010AA_bug_matches_x12n_document_resJson(self):
+        # Walker-level error fixture (Mandatory loop missing). The seg
+        # error is emitted by the walker during iter_segments and lands
+        # on the tree via apply_walk_errors(self.errh, walk_errors).
+        actual = self._json_via_context_reader("bad_2010AA_bug")
+        self.assertEqual(actual, datafiles["bad_2010AA_bug"]["resJson"])
+
+    def test_simple_837p_round_trip(self):
+        # No fixture comparison — just verify that a real 837P document
+        # round-trips through iter_segments without raising and produces
+        # a structurally-complete JSON document with the right top-level
+        # shape (interchanges/groups/transactions/segments).
+        doc = self._json_via_context_reader("simple_837p")
+        self.assertIn("interchanges", doc)
+        self.assertEqual(len(doc["interchanges"]), 1)
+        groups = doc["interchanges"][0]["groups"]
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(groups[0]["transactions"]), 1)

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -28,6 +28,7 @@ import pyx12
 import pyx12.segment
 
 from . import error_handler, errors, map_if, map_index, path, x12file
+from .map_if._segment import apply_segment_errors
 from .map_walker import apply_walk_errors, pop_to_parent_loop, walk_tree
 
 
@@ -827,7 +828,7 @@ class X12ContextReader:
 
     param: Any
     map_path: str | None
-    errh: error_handler.errh_list
+    errh: Any
     icvn: str | None
     fic: str | None
     vriic: str | None
@@ -856,7 +857,17 @@ class X12ContextReader:
         """
         self.param = param
         self.map_path = map_path
-        self.errh = error_handler.errh_list()
+        # Use the caller's error handler. The historical hardcode here
+        # discarded the parameter, leaving callers no way to capture
+        # validation errors (and `iter_segments` only ever attached
+        # errors to data nodes via a fresh local errh_list, never
+        # populating a tree). Threading the parameter through unlocks
+        # the err_handler tree path: callers who pass an
+        # `error_handler.err_handler()` get a populated tree they can
+        # walk with a visitor (e.g. `errh_json_visitor`); callers who
+        # keep passing `errh_null()` see no behavior change since all
+        # the lifecycle methods are no-ops there.
+        self.errh = errh
         self.icvn = None
         self.fic = None
         self.vriic = None
@@ -926,6 +937,10 @@ class X12ContextReader:
                         self.src.get_ls_id(),
                     )
                     apply_walk_errors(errh, walk_errors)
+                    # Also propagate the same walker errors into the caller's
+                    # error handler so the err_handler tree (when caller
+                    # passed `error_handler.err_handler()`) carries them.
+                    apply_walk_errors(self.errh, walk_errors)
                     self.x12_map_node = seg_node
                 except errors.EngineError:
                     raise
@@ -935,6 +950,11 @@ class X12ContextReader:
                 seg_id = seg.get_seg_id()
                 if seg_id == "ISA":
                     icvn = seg.get_value("ISA12")
+                    self.errh.add_isa_loop(seg, self.src)
+                    self.errh.handle_errors(self.src.pop_errors())
+                elif seg_id == "IEA":
+                    self.errh.handle_errors(self.src.pop_errors())
+                    self.errh.close_isa_loop(self.x12_map_node, seg, self.src)
                 elif seg_id == "GS":
                     fic = seg.get_value("GS01")
                     vriic = seg.get_value("GS08")
@@ -954,6 +974,17 @@ class X12ContextReader:
                     self._reset_counter_to_gs_counts()
                     tpath = "/ISA_LOOP/GS_LOOP/GS"
                     self.x12_map_node = cur_map.getnodebypath(tpath)
+                    self.errh.add_gs_loop(seg, self.src)
+                    self.errh.handle_errors(self.src.pop_errors())
+                elif seg_id == "GE":
+                    self.errh.handle_errors(self.src.pop_errors())
+                    self.errh.close_gs_loop(self.x12_map_node, seg, self.src)
+                elif seg_id == "ST":
+                    self.errh.add_st_loop(seg, self.src)
+                    self.errh.handle_errors(self.src.pop_errors())
+                elif seg_id == "SE":
+                    self.errh.handle_errors(self.src.pop_errors())
+                    self.errh.close_st_loop(self.x12_map_node, seg, self.src)
                 elif seg_id == "BHT":
                     if vriic in ("004010X094", "004010X094A1"):
                         tspc = seg.get_value("BHT02")
@@ -976,6 +1007,34 @@ class X12ContextReader:
                             self._apply_loop_count(self.x12_map_node, cur_map)
                             tpath = "/ISA_LOOP/GS_LOOP/ST_LOOP/HEADER/BHT"
                             self.x12_map_node = cur_map.getnodebypath(tpath)
+                    self.errh.add_seg(
+                        self.x12_map_node,
+                        seg,
+                        self.src.get_seg_count(),
+                        self.src.get_cur_line(),
+                        self.src.get_ls_id(),
+                    )
+                    self.errh.handle_errors(self.src.pop_errors())
+                else:
+                    self.errh.add_seg(
+                        self.x12_map_node,
+                        seg,
+                        self.src.get_seg_count(),
+                        self.src.get_cur_line(),
+                        self.src.get_ls_id(),
+                    )
+                    self.errh.handle_errors(self.src.pop_errors())
+                # Run element / segment-level validation against the
+                # caller's error handler. Skipped for envelope segments
+                # which are matched via the control map and not the
+                # transaction map; element validation against the control
+                # map is x12n_document's job, not the streaming context
+                # reader's. errh_null silently absorbs all of these calls
+                # so existing context-reader tests are unchanged.
+                if seg_id not in ("ISA", "IEA", "GS", "GE", "ST", "SE") and isinstance(
+                    self.x12_map_node, map_if.segment_if
+                ):
+                    apply_segment_errors(self.x12_map_node, seg, self.errh)
 
             node_x12path = self.x12_map_node.x12path
             # If we are in the requested tree, wait until we have the whole thing


### PR DESCRIPTION
Slice #4 of [issue #50](https://github.com/azoner/pyx12/issues/50). Builds on the visitor (#163), orchestrator wiring (#164), and resJson fixture corpus (#165).

## Background

`X12ContextReader.__init__` historically declared an `errh` parameter and then **ignored it**, hardcoding `errh_list()` (a flat list, not walkable by a visitor). `iter_segments` only ever attached errors to data nodes via a fresh local `errh_list` per segment, never building a tree. Callers had no path from a context-reader run to the err_handler tree shape that 997/999 visitors and the new `errh_json_visitor` expect.

## What this slice does

- **`pyx12/x12context.py:859`** — `self.errh = errh` (was `errh_list()`). Type annotation widened from `errh: errh_list` to `errh: Any`. This is what unlocks the JSON-via-context-reader path.
- **`pyx12/x12context.py` `iter_segments`** — adds the same hierarchy lifecycle calls `x12n_document.py` uses (`add_isa_loop`/`add_gs_loop`/`add_st_loop` and their `close_*` counterparts on IEA/GE/SE, plus `add_seg` for BHT and regular segments). For non-envelope segments, runs `apply_segment_errors` to populate element-level errors on the tree. The local `errh_list` flow for per-data-node attachment is preserved unchanged.
- **`pyx12/test/test_x12context.py`** — new `JsonErrorOutput` class with three regression tests proving the X12ContextReader path produces the **same JSON document** as the x12n_document path:
  - `834_lui_id` (clean fixture, `ack_code=A` everywhere)
  - `bad_2010AA_bug` (walker-level error, \"Mandatory loop missing\")
  - `simple_837p` (round-trip structural shape)

## Backward compatibility

`errh_null` implements all the lifecycle methods as no-ops, so the **47 existing `test_x12context` tests pass unchanged**. `errh_list`-based callers (none in-tree) would still see the per-data-node `errh_list` flow they relied on.

## Test plan

- [x] pytest pyx12/test/: 574 passed (571 baseline from #165 merge + 3 new JsonErrorOutput tests)
- [x] mypy --strict pyx12: clean (85 files)
- [x] ruff check + ruff format --check: clean
- [x] All 47 existing test_x12context tests still pass with their existing `errh_null()` parameter

## What this does NOT do

- Does not address [issue #120](https://github.com/azoner/pyx12/issues/120) (CTX enrichment in `error_999.py` IK3/IK4) — that's slice #5 (next PR)
- Does not change `x12n_document` or the JSON visitor itself — pure x12context refactor + test addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)