### PR TITLE
release: 4.0.0rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyx12"
-version = "4.0.0rc3"
+version = "4.0.0rc4"
 description = "HIPAA X12 validator, parser and converter"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyx12/version.py
+++ b/pyx12/version.py
@@ -1,1 +1,1 @@
-__version__ = "4.0.0rc3"
+__version__ = "4.0.0rc4"


### PR DESCRIPTION
## Summary
- Bumps version to `4.0.0rc4` in [pyproject.toml](pyproject.toml) and [pyx12/version.py](pyx12/version.py).
- Picks up the issue #50 work (PRs #163-#166) on top of `4.0.0rc3`.

## What's new since rc3

- **JSON error output (issue #50, closed).** New `pyx12.errh_json.errh_json_visitor` walks the err_handler tree and emits a nested JSON document mirroring the ISA / GS / ST / segment / element hierarchy.
  ```
  x12valid -J -- input.x12   →   input.x12.json
  ```
- **`X12ContextReader` rewired (#166).** Highest-blast-radius change in the bunch. The historical `errh_list()` hardcode in `__init__` is gone; the passed-in `errh` is now actually used. New lifecycle calls match `x12n_document.py`'s pattern. `errh_null` no-ops them all so existing callers see no behavior change.
- **Regression coverage.** `resJson` fixtures across the `x12testdata.py` corpus (PR #165, ~2200 lines of pure data); paired `_test_<key>_json` methods on `test_x12n_document.py`; new `JsonErrorOutput` class on `test_x12context.py` proves both orchestrator paths produce identical JSON.

## Pre-flight (via `/publish dryrun`)
- [x] pytest: **574 passed** (539 baseline at rc3 + 35 new JSON tests across the four issue-#50 PRs)
- [x] mypy --strict: clean (85 files)
- [x] ruff check: clean
- [x] ruff format --check: clean
- [x] tools/check_maps.py: 32 maps clean
- [x] tools/test_install.py: post-packaging install clean

## Test plan
- [ ] CI green on this PR (4 Python builds + mypy strict + maps + post-packaging + docs).
- [ ] After merge: `/publish` cuts the `v4.0.0rc4` tag → release.yml → TestPyPI + PyPI → GitHub pre-release.
- [ ] Smoke `swmbh-x12-sbus` against `pyx12==4.0.0rc4`. The X12ContextReader refactor is the load-bearing test target — production traffic should populate the err_handler tree exactly as it did pre-refactor (errh_null no-ops the new calls).
- [ ] If clean: promote to `4.0.0` final using `release-notes-4.0.0.md` as `--notes-file`. If a regression surfaces: fix PR → rc5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)