### PR TITLE
release: 4.0.0rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyx12"
-version = "4.0.0rc4"
+version = "4.0.0rc5"
 description = "HIPAA X12 validator, parser and converter"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyx12/version.py
+++ b/pyx12/version.py
@@ -1,1 +1,1 @@
-__version__ = "4.0.0rc4"
+__version__ = "4.0.0rc5"


### PR DESCRIPTION
## Summary
- Bumps version to `4.0.0rc5` in [pyproject.toml](pyproject.toml) and [pyx12/version.py](pyx12/version.py).
- Picks up [PR #168](https://github.com/azoner/pyx12/pull/168) (examples/ Python 3 modernization + `docs/examples.rst`) on top of `4.0.0rc4`.

## What's new since rc4

- **Examples modernized for Python 3 + new docs page** (#168). Modernizes the bundled example scripts (`pyx12/examples/*.py`) and adds an `Examples` section to the Sphinx docs at `docs/examples.rst`. Examples are not shipped in the wheel (excluded by `tool.setuptools.packages.find`), so this changes nothing about the runtime library — diff is contained to docs build content + example source.

## Pre-flight (via `/publish dryrun`)
- [x] pytest: 574 passed
- [x] mypy --strict: clean (87 files)
- [x] ruff check + ruff format --check: clean
- [x] tools/check_maps.py: 32 maps clean
- [x] tools/test_install.py: post-packaging install clean

## Test plan
- [ ] CI green on this PR
- [ ] After merge: `/publish` cuts the `v4.0.0rc5` tag → release.yml → TestPyPI + PyPI → GitHub pre-release
- [ ] No new pyx12 library code path vs rc4, so swmbh-x12-sbus validation can be skipped on rc5 if rc4 already passed (or run again for completeness)
- [ ] Promote to `4.0.0` final using [`release-notes-4.0.0.md`](https://github.com/azoner/pyx12) as `--notes-file` once worker validation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)