### PR TITLE
fix: bind iter_segments push/pop loops correctly on streaming yields (#107)

### DIFF
--- a/pyx12/test/test_x12context.py
+++ b/pyx12/test/test_x12context.py
@@ -642,3 +642,31 @@ class JsonErrorOutput(X12fileTestCase):
         groups = doc["interchanges"][0]["groups"]
         self.assertEqual(len(groups), 1)
         self.assertEqual(len(groups[0]["transactions"]), 1)
+
+
+class IterSegmentsBindings(X12fileTestCase):
+    """Regression for #107: ``iter_segments`` historically constructed
+    ``X12SegmentDataNode`` with positional args that bound ``push_loops``
+    to ``parent`` and ``pop_loops`` to ``start_loops``, leaving
+    ``end_loops`` empty. The downstream ``parent is None`` guard was
+    spuriously bypassed because a list (even an empty one) is not None.
+    Verify the corrected semantics."""
+
+    def test_streaming_yield_parent_is_node_or_none(self):
+        # parent should be None or an X12DataNode, never a list (the bug).
+        fd = self._makeFd(datafiles["simple_837p"]["source"])
+        errh = pyx12.error_handler.errh_null()
+        src = pyx12.x12context.X12ContextReader(self.param, errh, fd)
+        for seg in src.iter_segments():
+            self.assertFalse(isinstance(seg.parent, list))
+
+    def test_some_segment_closes_a_loop(self):
+        # In any non-trivial 837 there is at least one segment whose
+        # arrival closes a previous loop. Under the misbinding,
+        # ``end_loops`` defaulted to ``[]`` for every yield, so this
+        # assertion would never hold.
+        fd = self._makeFd(datafiles["simple_837p"]["source"])
+        errh = pyx12.error_handler.errh_null()
+        src = pyx12.x12context.X12ContextReader(self.param, errh, fd)
+        any_popped = any(seg.end_loops for seg in src.iter_segments())
+        self.assertTrue(any_popped)

--- a/pyx12/x12context.py
+++ b/pyx12/x12context.py
@@ -1086,16 +1086,12 @@ class X12ContextReader:
                         raise errors.EngineError(
                             "Loop ID %s should not be in pop loops" % (loop_id)
                         )
-                    # NOTE: positional args here are intentionally what they
-                    # appear to be even though it looks wrong (`parent` gets
-                    # `push_loops` which is a list). The downstream None-check
-                    # for `parent` relies on this list being truthy. See the
-                    # test_x12context.TreeCopy tests.
                     cur_data_node = X12SegmentDataNode(
                         self.x12_map_node,
                         seg,
-                        push_loops,  # type: ignore[arg-type]
-                        pop_loops,
+                        parent=None,
+                        start_loops=push_loops,
+                        end_loops=pop_loops,
                     )
                     cur_data_node.seg_count = self.src.get_seg_count()
                     cur_data_node.cur_line_number = self.src.get_cur_line()
@@ -1107,9 +1103,6 @@ class X12ContextReader:
                 errh.handle_errors(self.src.pop_errors())
                 # Handle errors captured in errh_list
                 cur_data_node.handle_errh_errors(errh)
-                if cur_data_node.id != "ISA" and cur_data_node is not None:
-                    if cur_data_node.parent is None:
-                        raise errors.EngineError('Node "%s" has no parent' % (cur_data_node.id))
                 yield cur_data_node
 
     def register_error_callback(self, callback: Any, err_type: str) -> None:


### PR DESCRIPTION
Closes #107.

## Summary

`X12ContextReader.iter_segments` constructs `X12SegmentDataNode` on the streaming-yield branch with positional args that don't match the constructor signature:

```python
# Was:
X12SegmentDataNode(self.x12_map_node, seg, push_loops, pop_loops)
# Constructor:
__init__(self, x12_node, seg_data, parent=None, start_loops=None, end_loops=None)
```

So `push_loops` → `parent` (a list, not a node), `pop_loops` → `start_loops`, and `end_loops` → `[]` (default). PR #105 worked around it with a `# type: ignore[arg-type]` and a comment explaining the wrong-looking call.

The substantive bug is the **`start_loops` / `end_loops` semantic swap**: callers reading `seg.start_loops` on streaming yields got the *popped* loops; `seg.end_loops` was always empty. The typed `parent`-is-list bug was mostly latent — only `__copy__` (just propagates) and a spurious `parent is None` guard read `.parent`, and the guard never fired (a list, even an empty one, isn't `None`).

## Changes

- [pyx12/x12context.py:1094-1099](pyx12/x12context.py#L1094-L1099) — kwargs: `parent=None, start_loops=push_loops, end_loops=pop_loops`. Streaming yields are freestanding from a parent-loop perspective by design (the tree-build branch at `_add_segment` already gives those segments a real parent).
- [pyx12/x12context.py:1110-1112](pyx12/x12context.py#L1110-L1112) — remove the `if cur_data_node.parent is None: raise EngineError(...)` guard. It's been silently passing for years because `push_loops` (always a list) bypassed the None check; removing it surfaces no real failures.
- `# type: ignore[arg-type]` and the explanatory comment go away.
- New `IterSegmentsBindings` test class in `test_x12context.py` with two regressions:
  - `seg.parent` is never a `list` on streaming yields
  - At least one segment in a real 837 has `end_loops` populated (caught the always-`[]` symptom)

## Test plan

- [x] pytest pyx12/test/: **576 passed** (574 baseline + 2 new regressions)
- [x] mypy --strict pyx12: clean (87 files, `# type: ignore` removed)
- [x] ruff check + format --check: clean
- [x] The issue body's \"47 tests fail with a naive kwarg fix\" estimate was stale (likely pre-dating the producer-side errors-as-data refactor); the current suite passes without any test re-derivation.

## ⚠️ Behavior change — hold on swmbh-x12-sbus cross-check

This is a behavior change for any consumer that reads `seg.start_loops` or `seg.end_loops` on streaming-yielded segments. Tag for **4.1.0**.

**Before merging,** cross-check swmbh-x12-sbus for `seg.start_loops` / `seg.end_loops` field accesses. If the worker has been compensating for the swap, those compensations will need to flip when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)