### PR TITLE
fix: remove dead-code err_handler.find_node and stubs (#108)

### DIFF
--- a/pyx12/errh_xml.py
+++ b/pyx12/errh_xml.py
@@ -292,12 +292,6 @@ class errh_list:
         """ """
         pass
 
-    def find_node(self, atype: str) -> None:
-        """
-        Find the last node of a type
-        """
-        pass
-
     def get_parent(self) -> None:
         return None
 

--- a/pyx12/error_handler.py
+++ b/pyx12/error_handler.py
@@ -338,15 +338,6 @@ class err_handler:
         self.cur_seg_node = self.cur_st_node
         self.seg_node_added = True
 
-    def find_node(self, type: str) -> None:
-        """
-        Find the last node of a type
-        """
-        new_node = self.cur_node
-        node_order = {"ROOT": 1, "ISA": 2, "GS": 3, "ST": 4, "SEG": 5, "ELE": 6}
-        while node_order[type] > new_node[new_node.get_id()]:
-            new_node = new_node.get_parent()
-
     def _get_last_child(self) -> Any:
         """ """
         if len(self.children) != 0:
@@ -1143,12 +1134,6 @@ class errh_null:
         """ """
         pass
 
-    def find_node(self, type: str) -> None:
-        """
-        Find the last node of a type
-        """
-        pass
-
     def get_parent(self) -> None:
         return None
 
@@ -1312,9 +1297,6 @@ class errh_list:
         pass
 
     def close_st_loop(self, node: Any, seg: Any, src: Any) -> None:
-        pass
-
-    def find_node(self, type: str) -> None:
         pass
 
     def get_parent(self) -> None:


### PR DESCRIPTION
Closes #108.

`err_handler.find_node` had a guaranteed-`TypeError` subscript bug — `new_node[new_node.get_id()]` subscripts a node with a string, but none of the `err_*` node classes implement `__getitem__`. The bug never surfaced because **nothing in the repo calls `find_node`**.

Three classes had matching stub `find_node` definitions: `errh_null`, `errh_list`, and `errh_xml.errh_list`. All four are deleted.

## Diff

```
 pyx12/errh_xml.py      |  6 ------
 pyx12/error_handler.py | 18 ------------------
```

## Test plan

- [x] Repo-wide `grep -r find_node` returns zero hits after this PR (was 4 definitions, 0 callers)
- [x] pytest pyx12/test/: 576 passed
- [x] mypy --strict pyx12: clean (87 files)
- [x] ruff check + format --check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)