### PR TITLE
fix: handle non-ASCII bytes in X12 input gracefully (#157)

### DIFF
--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 from io import StringIO
@@ -259,3 +260,29 @@ class TestTemp(X12DocumentTestCase):
         pyx12.x12n_document.x12n_document(param, fd_source, fd_997, fd_html, None)
         fd_997.seek(0)
         # self._isX12Diff(fd_997_base, fd_997)
+
+
+class UnicodeInput(X12DocumentTestCase):
+    """Regression for #157: non-ASCII bytes in the input file must
+    surface as validation errors, not a UnicodeDecodeError that crashes
+    the parser. Historically `open(..., encoding='ascii')` raised on
+    the first non-ASCII byte; the file is now opened with latin-1 (a
+    never-fail single-byte codec), so non-ASCII codepoints are passed
+    through to the validator where rec_ID_B / rec_ID_E reject them via
+    normal error paths."""
+
+    def test_non_ascii_byte_does_not_raise(self):
+        # Embed `é` (0xE9 in latin-1) inside a REF02 value of a real fixture.
+        source = datafiles["834_lui_id"]["source"].replace("REF*0F*00389999", "REF*0F*00389\xe9999")
+        # Write the source to a tempfile so x12n_document opens it via the
+        # filename path (i.e. exercises the encoding choice in X12Reader).
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".x12", delete=False) as f:
+            f.write(source.encode("latin-1"))
+            temppath = f.name
+        try:
+            fd_997 = StringIO()
+            # Must not raise UnicodeDecodeError. Return value can be either
+            # — what matters is that the parser ran end-to-end.
+            pyx12.x12n_document.x12n_document(self.param, temppath, fd_997, None, None)
+        finally:
+            os.unlink(temppath)

--- a/pyx12/x12file.py
+++ b/pyx12/x12file.py
@@ -347,7 +347,14 @@ class X12Reader(X12Base):
             if src_file_obj == "-":
                 self.fd_in = sys.stdin
             else:
-                self.fd_in = open(src_file_obj, encoding="ascii")  # type: ignore[arg-type]
+                # X12 requires ASCII, but a non-ASCII byte in the input
+                # should surface as a validation error (caught by the
+                # rec_ID_* regexes in pyx12.validation), not a parse-time
+                # UnicodeDecodeError that crashes the whole pipeline.
+                # latin-1 maps every byte 0-255 to a Unicode codepoint and
+                # never raises, so non-ASCII bytes get through to the
+                # validator where they're rejected by normal error paths.
+                self.fd_in = open(src_file_obj, encoding="latin-1")  # type: ignore[arg-type]
                 self.need_to_close = True
         X12Base.__init__(self)
         try:


### PR DESCRIPTION
Closes #157.

`X12Reader` opened source files with `encoding=\"ascii\"`, so the first non-ASCII byte raised `UnicodeDecodeError` and crashed the whole pipeline before validation could run. Switch to `encoding=\"latin-1\"` — a never-fail single-byte codec that maps every byte 0-255 to a Unicode codepoint. Non-ASCII bytes are passed through to the validator where the existing `rec_ID_B` / `rec_ID_E` / `rec_ID_E5` regex patterns reject them via normal error paths.

## Why latin-1 (not utf-8)

X12 is ASCII-by-spec, so non-ASCII bytes are invalid regardless of source encoding intent. latin-1 wins over utf-8 here because:

- **1 byte → 1 codepoint** preserves byte-position fidelity (line/column counts, `cur_line` reporting, element offsets stay accurate). UTF-8 collapses multi-byte sequences to a single codepoint, shifting positions.
- **Never raises on torn multi-byte sequences.** A stray 0xC3 without continuation byte would still crash plain `utf-8`; latin-1 just decodes it.
- **Diagnosability.** Codepoint value equals byte value (e.g. 0xE9 → U+00E9), so error messages match a hex dump.

The cost is mojibake on actually-UTF-8 content (a real `é` reads as `Ã©`), but the validator rejects both forms — no crash either way.

## Diff

```
 pyx12/test/test_x12n_document.py | 27 +++++++++++++++++++++++++++
 pyx12/x12file.py                 |  9 ++++++++-
```

## Test plan

- [x] New regression test (`UnicodeInput::test_non_ascii_byte_does_not_raise`) writes a 0xE9 byte into an 834 fixture element, parses via `x12n_document(filename)`, asserts no exception is raised. Would fail under `encoding=\"ascii\"`.
- [x] pytest pyx12/test/: **577 passed** (576 baseline + 1 new)
- [x] mypy --strict pyx12: clean (87 files)
- [x] ruff check + format --check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)