### PR TITLE
feat: migrate _element.py producers to pyx12 codes (PR 2 of 6)

### DIFF
--- a/pyx12/error_item.py
+++ b/pyx12/error_item.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .error_codes import ERROR_CODES
 from .errors import EngineError
 
 isa_errors = (
@@ -83,7 +84,11 @@ class SegError(ErrorItem):
     ls_id: str | None = None
 
     def __post_init__(self) -> None:
-        if self.err_cde not in seg_errors:
+        # During the PR 2-4 producer migration, accept either legacy
+        # raw-X12 codes ("1"-"8") or new pyx12 codes from ERROR_CODES.
+        # PR 5 narrows this to ERROR_CODES only once every producer has
+        # migrated.
+        if self.err_cde not in seg_errors and self.err_cde not in ERROR_CODES:
             raise EngineError('Invalid segment level error code "%s"' % (self.err_cde))
 
 
@@ -98,5 +103,9 @@ class EleError(ErrorItem):
     map_node: Any = None
 
     def __post_init__(self) -> None:
-        if self.err_cde not in ele_errors:
+        # During the PR 2-4 producer migration, accept either legacy
+        # raw-X12 codes ("1"-"10") or new pyx12 codes from ERROR_CODES.
+        # PR 5 narrows this to ERROR_CODES only once every producer has
+        # migrated.
+        if self.err_cde not in ele_errors and self.err_cde not in ERROR_CODES:
             raise EngineError('Invalid element level error code "%s"' % (self.err_cde))

--- a/pyx12/map_if/_element.py
+++ b/pyx12/map_if/_element.py
@@ -21,6 +21,22 @@ import pyx12.segment
 
 from .. import validation
 from ..dataele import _DataEle
+from ..error_codes import (
+    ELE_1_MANDATORY_MISSING,
+    ELE_4_TOO_SHORT,
+    ELE_5_TOO_LONG,
+    ELE_6_CONTROL_CHAR,
+    ELE_6_INVALID_COMPOSITE,
+    ELE_6_INVALID_TYPE_CHAR,
+    ELE_6_TRAILING_SPACE,
+    ELE_7_INVALID_CODE,
+    ELE_7_REGEX_FAIL,
+    ELE_8_INVALID_DATE,
+    ELE_8_INVALID_DATE_RANGE,
+    ELE_9_INVALID_TIME,
+    ELE_9_INVALID_TIME_OF_DAY,
+    ELE_10_NOT_USED,
+)
 from ..error_item import EleError
 from ..errors import EngineError
 from ._base import _required_attr, x12_node
@@ -169,14 +185,14 @@ class element_if(x12_node):
 
         if elem and elem.is_composite():
             err_str = 'Data element "%s" (%s) is an invalid composite' % (self.name, self.refdes)
-            errors.append(self._ele_error("6", err_str, elem.__repr__()))
+            errors.append(self._ele_error(ELE_6_INVALID_COMPOSITE, err_str, elem.__repr__()))
             return False, errors
         if elem is None or elem.get_value() == "":
             empty_errors = self._validate_when_empty()
             return (not empty_errors, empty_errors)
         if self.usage == "N" and elem.get_value() != "":
             err_str = 'Data element "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
-            errors.append(self._ele_error("10", err_str, None))
+            errors.append(self._ele_error(ELE_10_NOT_USED, err_str, None))
             return False, errors
 
         elem_val = elem.get_value()
@@ -203,7 +219,7 @@ class element_if(x12_node):
             self.seq != 1 or not self.parent.is_composite() or self.parent.usage == "R"
         ):
             err_str = 'Mandatory data element "%s" (%s) is missing' % (self.name, self.refdes)
-            return [self._ele_error("1", err_str, None)]
+            return [self._ele_error(ELE_1_MANDATORY_MISSING, err_str, None)]
         return []
 
     def _validate_length(self, elem_val: str) -> list[EleError]:
@@ -226,7 +242,7 @@ class element_if(x12_node):
                 elem_len,
                 min_len,
             )
-            out.append(self._ele_error("4", err_str, elem_val))
+            out.append(self._ele_error(ELE_4_TOO_SHORT, err_str, elem_val))
         if elem_len > max_len:
             err_str = 'Data element "%s" (%s) is too long: len("%s") = %i > %i (max_len)' % (
                 self.name,
@@ -235,7 +251,7 @@ class element_if(x12_node):
                 elem_len,
                 max_len,
             )
-            out.append(self._ele_error("5", err_str, elem_val))
+            out.append(self._ele_error(ELE_5_TOO_LONG, err_str, elem_val))
         return out
 
     def _validate_control_chars(self, elem_val: str) -> list[EleError]:
@@ -247,7 +263,7 @@ class element_if(x12_node):
             self.refdes,
             bad_string,
         )
-        return [self._ele_error("6", err_str, bad_string)]
+        return [self._ele_error(ELE_6_CONTROL_CHAR, err_str, bad_string)]
 
     def _validate_trailing_spaces(self, elem_val: str) -> list[EleError]:
         data_ele = self._resolve_data_ele()
@@ -260,7 +276,7 @@ class element_if(x12_node):
             self.refdes,
             elem_val,
         )
-        return [self._ele_error("6", err_str, elem_val)]
+        return [self._ele_error(ELE_6_TRAILING_SPACE, err_str, elem_val)]
 
     def _validate_data_type(self, elem_val: str) -> list[EleError]:
         data_type = self._resolve_data_ele()["data_type"]
@@ -277,21 +293,21 @@ class element_if(x12_node):
                 self.refdes,
                 elem_val,
             )
-            return [self._ele_error("8", err_str, elem_val)]
+            return [self._ele_error(ELE_8_INVALID_DATE, err_str, elem_val)]
         if data_type == "TM":
             err_str = 'Data element "%s" (%s) contains an invalid time (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            return [self._ele_error("9", err_str, elem_val)]
+            return [self._ele_error(ELE_9_INVALID_TIME, err_str, elem_val)]
         err_str = 'Data element "%s" (%s) is type %s, contains an invalid character(%s)' % (
             self.name,
             self.refdes,
             data_type,
             elem_val,
         )
-        return [self._ele_error("6", err_str, elem_val)]
+        return [self._ele_error(ELE_6_INVALID_TYPE_CHAR, err_str, elem_val)]
 
     def _validate_type_list(self, elem_val: str, type_list: list[str | None]) -> list[EleError]:
         valid_type = False
@@ -308,14 +324,14 @@ class element_if(x12_node):
                 self.refdes,
                 elem_val,
             )
-            return [self._ele_error("9", err_str, elem_val)]
+            return [self._ele_error(ELE_9_INVALID_TIME_OF_DAY, err_str, elem_val)]
         if any(t in type_list for t in ("RD8", "DT", "D8", "D6")):
             err_str = 'Data element "%s" (%s) contains an invalid date (%s)' % (
                 self.name,
                 self.refdes,
                 elem_val,
             )
-            return [self._ele_error("8", err_str, elem_val)]
+            return [self._ele_error(ELE_8_INVALID_DATE_RANGE, err_str, elem_val)]
         return []
 
     def _validate_regex(self, elem_val: str) -> list[EleError]:
@@ -323,7 +339,7 @@ class element_if(x12_node):
             return []
         err_str = 'Data element "%s" with a value of (%s)' % (self.name, elem_val)
         err_str += ' failed to match the regular expression "%s"' % (self.res)
-        return [self._ele_error("7", err_str, elem_val)]
+        return [self._ele_error(ELE_7_REGEX_FAIL, err_str, elem_val)]
 
     def _is_valid_code(self, elem_val: str) -> list[EleError]:
         if not self._valid_codes_set and self.external_codes is None:
@@ -335,7 +351,7 @@ class element_if(x12_node):
         ):
             return []
         err_str = "(%s) is not a valid code for %s (%s)" % (elem_val, self.name, self.refdes)
-        return [self._ele_error("7", err_str, elem_val)]
+        return [self._ele_error(ELE_7_INVALID_CODE, err_str, elem_val)]
 
     def get_data_type(self) -> str | None:
         return self._resolve_data_ele()["data_type"]

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -22,7 +22,7 @@ class ElementIsValidDate(unittest.TestCase):
         node = self.node.getnodebypath("DTP[434]")
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["8"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_8_invalid_date_range"])
 
     def test_date_ok1(self):
         seg_data = pyx12.segment.Segment("DTP*435*D8*20040110~", "~", "*", ":")
@@ -36,7 +36,7 @@ class ElementIsValidDate(unittest.TestCase):
         node = self.node.getnodebypath("DTP[096]")
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["9"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_9_invalid_time_of_day"])
 
     def test_time_ok1(self):
         seg_data = pyx12.segment.Segment("DTP*096*TM*1215~", "~", "*", ":")
@@ -63,7 +63,7 @@ class ElementIsValidDate(unittest.TestCase):
         self.assertNotEqual(node, None)
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["8"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_8_invalid_date_range"])
 
     def test_date_1251_bad2(self):
         seg_data = pyx12.segment.Segment("DMG*D8*20040109-20040110*M~", "~", "*", ":")
@@ -71,7 +71,7 @@ class ElementIsValidDate(unittest.TestCase):
         self.assertNotEqual(node, None)
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["8"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_8_invalid_date_range"])
 
     def test_date_1251_ok2(self):
         seg_data = pyx12.segment.Segment("DTP*434*RD8*20110101-20110220~", "~", "*", ":")
@@ -133,7 +133,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("-5.234426732456733454")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["5"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_5_too_long"])
 
     def test_bad_char_R(self):
         node = self.node.get_child_node_by_idx(1)
@@ -144,7 +144,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("-5.AB4")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["6"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_6_invalid_type_char"])
 
     def test_valid_codes_ok1(self):
         # CLM05-01   02 bad, 11 good, no external
@@ -167,7 +167,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("AA")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["7"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_7_invalid_code"])
 
     def test_valid_codes_bad_spaces(self):
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/2400/SV1")
@@ -179,7 +179,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("  ")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["7"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_7_invalid_code"])
 
     def test_external_codes_ok1(self):
         # CLM11-04 external states, no valid_codes
@@ -202,7 +202,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("NA")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["7"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_7_invalid_code"])
 
     def test_bad_passed_comp_to_ele_node(self):
         node = self.node.get_child_node_by_idx(0)
@@ -212,7 +212,7 @@ class ElementIsValid(unittest.TestCase):
         comp = pyx12.segment.Composite("NA::1", ":")
         result, errors = node.is_valid_errors(comp)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["6"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_6_invalid_composite"])
 
     def test_null_N(self):
         node = self.node.get_child_node_by_idx(2)
@@ -259,7 +259,7 @@ class ElementIsValid(unittest.TestCase):
         self.assertEqual(node.base_name, "element")
         result, errors = node.is_valid_errors(None)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["1"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_1_mandatory_missing"])
 
     def test_blank_R(self):
         node = self.node.get_child_node_by_idx(0)
@@ -269,7 +269,7 @@ class ElementIsValid(unittest.TestCase):
         elem = pyx12.segment.Element("")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["1"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_1_mandatory_missing"])
 
 
 class GetNodeByPath(unittest.TestCase):
@@ -447,7 +447,7 @@ class TrailingSpaces(unittest.TestCase):
         elem = pyx12.segment.Element("TEST     ")
         result, errors = node.is_valid_errors(elem)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["6"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_6_trailing_space"])
 
 
 class ElementRequirement(unittest.TestCase):
@@ -464,7 +464,7 @@ class ElementRequirement(unittest.TestCase):
         seg_data = pyx12.segment.Segment("REF*87*004010X098A1*Description*~", "~", "*", ":")
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["10"])
+        self.assertEqual([e.err_cde for e in errors], ["ELE_10_not_used"])
 
     def test_ele_required_ok1(self):
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/DETAIL/2000A/2000B/2300/CLM")

--- a/pyx12/test/x12testdata.py
+++ b/pyx12/test/x12testdata.py
@@ -1347,7 +1347,7 @@ IEA*1*000484889~""",
                                                     "name": "Explanation of Benefits Indicator",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "1",
+                                                            "err_cde": "ELE_1_mandatory_missing",
                                                             "x12_code": "1",
                                                             "err_str": 'Mandatory data element "Explanation of Benefits Indicator" (CLM18) is missing',
                                                             "err_val": None,
@@ -1568,7 +1568,7 @@ IEA*1*000000288~""",
                                                     "name": "Transmission Type Code",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(004010X098A2) is not a valid code for Transmission Type Code (REF02)",
                                                             "err_val": "004010X098A2",
@@ -1594,7 +1594,7 @@ IEA*1*000000288~""",
                                                     "name": "Communication Number Qualifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(TA) is not a valid code for Communication Number Qualifier (PER03)",
                                                             "err_val": "TA",
@@ -1620,7 +1620,7 @@ IEA*1*000000288~""",
                                                     "name": "Identification Code Qualifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(47) is not a valid code for Identification Code Qualifier (NM108)",
                                                             "err_val": "47",
@@ -1646,13 +1646,13 @@ IEA*1*000000288~""",
                                                     "name": "Identification Code Qualifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "5",
+                                                            "err_cde": "ELE_5_too_long",
                                                             "x12_code": "5",
                                                             "err_str": 'Data element "Identification Code Qualifier" (NM108) is too long: len("MIM") = 3 > 2 (max_len)',
                                                             "err_val": "MIM",
                                                         },
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(MIM) is not a valid code for Identification Code Qualifier (NM108)",
                                                             "err_val": "MIM",
@@ -1678,7 +1678,7 @@ IEA*1*000000288~""",
                                                     "name": "Subscriber Birth Date",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "8",
+                                                            "err_cde": "ELE_8_invalid_date_range",
                                                             "x12_code": "8",
                                                             "err_str": 'Data element "Subscriber Birth Date" (DMG02) contains an invalid date (19461301)',
                                                             "err_val": "19461301",
@@ -1693,7 +1693,7 @@ IEA*1*000000288~""",
                                                     "name": "Subscriber Gender Code",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(R) is not a valid code for Subscriber Gender Code (DMG03)",
                                                             "err_val": "R",
@@ -1719,7 +1719,7 @@ IEA*1*000000288~""",
                                                     "name": "Facility Type Code",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(95) is not a valid code for Facility Type Code (CLM05-01)",
                                                             "err_val": "95",
@@ -1881,7 +1881,7 @@ IEA*1*000238388~""",
                                                     "name": "Production Date",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "8",
+                                                            "err_cde": "ELE_8_invalid_date",
                                                             "x12_code": "8",
                                                             "err_str": 'Data element "Production Date" (DTM02) contains an invalid date (11111111)',
                                                             "err_val": "11111111",
@@ -2096,7 +2096,7 @@ IEA*1*000484889~""",
                                                     "name": "Product or Service ID Qualifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(  ) is not a valid code for Product or Service ID Qualifier (SV202-01)",
                                                             "err_val": "  ",
@@ -2111,7 +2111,7 @@ IEA*1*000484889~""",
                                                     "name": "Procedure Code",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "1",
+                                                            "err_cde": "ELE_1_mandatory_missing",
                                                             "x12_code": "1",
                                                             "err_str": 'Mandatory data element "Procedure Code" (SV202-02) is missing',
                                                             "err_val": None,
@@ -2137,7 +2137,7 @@ IEA*1*000484889~""",
                                                     "name": "Product or Service ID Qualifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "7",
+                                                            "err_cde": "ELE_7_invalid_code",
                                                             "x12_code": "7",
                                                             "err_str": "(  ) is not a valid code for Product or Service ID Qualifier (SVD03-01)",
                                                             "err_val": "  ",
@@ -2152,7 +2152,7 @@ IEA*1*000484889~""",
                                                     "name": "Procedure Code",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "1",
+                                                            "err_cde": "ELE_1_mandatory_missing",
                                                             "x12_code": "1",
                                                             "err_str": 'Mandatory data element "Procedure Code" (SVD03-02) is missing',
                                                             "err_val": None,
@@ -4588,7 +4588,7 @@ IEA*1*703201721~
                                                     "name": "Subscriber Identifier",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "6",
+                                                            "err_cde": "ELE_6_invalid_type_char",
                                                             "x12_code": "6",
                                                             "err_str": 'Data element "Subscriber Identifier" (REF02) is type AN, contains an invalid character(00389é999)',
                                                             "err_val": "00389é999",
@@ -4691,7 +4691,7 @@ IEA*1*311071503~
                                                     "name": "Member Address Line",
                                                     "errors": [
                                                         {
-                                                            "err_cde": "6",
+                                                            "err_cde": "ELE_6_control_char",
                                                             "x12_code": "6",
                                                             "err_str": 'Data element "Member Address Line" (N301), contains an invalid control character(<LF>)',
                                                             "err_val": "<LF>",


### PR DESCRIPTION
Second slice of the X12 error code generalization plan. Element-level validators now emit pyx12 codes (`ELE_1_mandatory_missing`, `ELE_6_invalid_composite`, `ELE_8_invalid_date`, etc.) instead of raw X12 codes. The 999/997 visitors translate via the ERROR_CODES table (in place since #175) so ack output is unchanged. JSON output's `err_cde` flips to pyx12 codes for element errors; `x12_code` still carries the X12-spec code.

## Producer migration (14 sites in `pyx12/map_if/_element.py`)

| Site | Before | After |
| --- | --- | --- |
| `_validate_when_empty` | `"1"` | `ELE_1_MANDATORY_MISSING` |
| `_validate_length` | `"4"`, `"5"` | `ELE_4_TOO_SHORT`, `ELE_5_TOO_LONG` |
| `_validate_control_chars` | `"6"` | `ELE_6_CONTROL_CHAR` |
| `_validate_trailing_spaces` | `"6"` | `ELE_6_TRAILING_SPACE` |
| `_validate_data_type` | `"8"`, `"9"`, `"6"` | `ELE_8_INVALID_DATE`, `ELE_9_INVALID_TIME`, `ELE_6_INVALID_TYPE_CHAR` |
| `_validate_type_list` | `"9"`, `"8"` | `ELE_9_INVALID_TIME_OF_DAY`, `ELE_8_INVALID_DATE_RANGE` |
| `_validate_regex` | `"7"` | `ELE_7_REGEX_FAIL` |
| `_is_valid_code` | `"7"` | `ELE_7_INVALID_CODE` |
| `is_valid_errors` | `"6"`, `"10"` | `ELE_6_INVALID_COMPOSITE`, `ELE_10_NOT_USED` |

## Test updates

- 14 `test_map_if` assertions updated to expect pyx12 codes from element-level paths.
- Composite/segment-level assertions (still emitting `"1"`, `"3"`, `"5"` from `_composite.py` and `_segment.py`) unchanged — those producers migrate in PR 3.
- resJson fixtures regenerated across the corpus: element errors now show `err_cde="ELE_X_..."` with `x12_code="X"` alongside. res997/resAck unchanged.

## Migration safety

`EleError` / `SegError` `__post_init__` validation relaxed to accept either legacy raw-X12 codes (`"1"`-`"10"`) or new pyx12 codes from `ERROR_CODES`. PR 5 will narrow this to `ERROR_CODES`-only once every producer has migrated.

## Test plan

- [x] pytest pyx12/test/: **579 passed** (no count change)
- [x] mypy --strict pyx12: clean (88 files)
- [x] ruff check + format --check: clean
- [x] res997/resAck fixtures unchanged (visitors translate to X12 codes at output)
- [x] resJson fixtures show pyx12 codes for element errors; segment/composite-level still raw X12 (PR 3 migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)