### PR TITLE
feat: migrate _composite.py + _segment.py producers to pyx12 codes (PR 3 of 6)

### DIFF
--- a/pyx12/map_if/_composite.py
+++ b/pyx12/map_if/_composite.py
@@ -18,6 +18,11 @@ from xml.etree.ElementTree import Element
 
 import pyx12.segment
 
+from ..error_codes import (
+    COMP_1_MANDATORY_MISSING,
+    COMP_3_TOO_MANY_SUBELEMENTS,
+    COMP_5_NOT_USED,
+)
 from ..error_item import EleError
 from ._base import _required_attr, x12_node
 from ._element import element_if
@@ -128,7 +133,9 @@ class composite_if(x12_node):
                     self.name,
                     self.refdes,
                 )
-                return False, [EleError(err_cde="1", err_str=err_str, refdes=self.refdes)]
+                return False, [
+                    EleError(err_cde=COMP_1_MANDATORY_MISSING, err_str=err_str, refdes=self.refdes)
+                ]
 
         # Past here, comp_data is non-None: the (None or empty)+(N/S) branch
         # short-circuited it; the R branch returned on missing comp_data.
@@ -136,11 +143,13 @@ class composite_if(x12_node):
 
         if self.usage == "N" and not comp_data.is_empty():
             err_str = 'Composite "%s" (%s) is marked as Not Used' % (self.name, self.refdes)
-            return False, [EleError(err_cde="5", err_str=err_str, refdes=self.refdes)]
+            return False, [EleError(err_cde=COMP_5_NOT_USED, err_str=err_str, refdes=self.refdes)]
 
         if len(comp_data) > self.get_child_count():
             err_str = 'Too many sub-elements in composite "%s" (%s)' % (self.name, self.refdes)
-            errors.append(EleError(err_cde="3", err_str=err_str, refdes=self.refdes))
+            errors.append(
+                EleError(err_cde=COMP_3_TOO_MANY_SUBELEMENTS, err_str=err_str, refdes=self.refdes)
+            )
             valid = False
         for i in range(min(len(comp_data), self.get_child_count())):
             ok, sub_errors = self.children[i].is_valid_errors(comp_data[i])

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -19,6 +19,12 @@ from xml.etree.ElementTree import Element
 
 import pyx12.segment
 
+from ..error_codes import (
+    SEG_2_SYNTAX_RELATIONAL,
+    SEG_3_TOO_MANY_ELEMENTS,
+    SEG_3_TOO_MANY_SUBELEMENTS,
+    SEG_10_SYNTAX_EXCLUSIVE,
+)
 from ..error_item import EleError
 from ..errors import EngineError
 from ..path import X12Path
@@ -396,7 +402,14 @@ class segment_if(x12_node):
             )
             ref_des = "%02i" % (child_count + 1)
             err_value = seg_data.get_value(ref_des)
-            errors.append(EleError(err_cde="3", err_str=err_str, err_val=err_value, refdes=ref_des))
+            errors.append(
+                EleError(
+                    err_cde=SEG_3_TOO_MANY_ELEMENTS,
+                    err_str=err_str,
+                    err_val=err_value,
+                    refdes=ref_des,
+                )
+            )
             valid = False
 
         dtype: list[str | None] = []
@@ -420,7 +433,7 @@ class segment_if(x12_node):
                     err_value = seg_data.get_value(ref_des)
                     errors.append(
                         EleError(
-                            err_cde="3",
+                            err_cde=SEG_3_TOO_MANY_SUBELEMENTS,
                             err_str=err_str,
                             err_val=err_value,
                             refdes=ref_des,
@@ -464,7 +477,7 @@ class segment_if(x12_node):
             if not bResult:
                 # When is_syntax_valid returns False, syn_err is the message string.
                 assert syn_err is not None
-                code = "10" if syn[0] == "E" else "2"
+                code = SEG_10_SYNTAX_EXCLUSIVE if syn[0] == "E" else SEG_2_SYNTAX_RELATIONAL
                 errors.append(EleError(err_cde=code, err_str=syn_err, refdes=syn[1]))
                 valid = False
 

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -94,7 +94,7 @@ class SegmentIsValid(unittest.TestCase):
         node = self.node.getnodebypath("DTP[435]")
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["3"])
+        self.assertEqual([e.err_cde for e in errors], ["SEG_3_too_many_elements"])
 
 
 class ElementIsValid(unittest.TestCase):
@@ -397,7 +397,7 @@ class CompositeRequirement(unittest.TestCase):
         comp = pyx12.segment.Composite("", ":")
         result, errors = node.is_valid_errors(comp)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["1"])
+        self.assertEqual([e.err_cde for e in errors], ["COMP_1_mandatory_missing"])
 
     def test_comp_not_used_fail1(self):
         node = self.map.getnodebypath("/ISA_LOOP/GS_LOOP/ST_LOOP/HEADER/REF")
@@ -408,7 +408,7 @@ class CompositeRequirement(unittest.TestCase):
         seg_data = pyx12.segment.Segment("REF*87*004010X098A1**:1~", "~", "*", ":")
         result, errors = node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["5"])
+        self.assertEqual([e.err_cde for e in errors], ["COMP_5_not_used"])
 
 
 class TrailingSpaces(unittest.TestCase):
@@ -752,7 +752,7 @@ class CompositeRequiredMissing(unittest.TestCase):
         seg_data = pyx12.segment.Segment("PLB*123*20211108**-100.00~", "~", "*", ":")
         result, errors = self.node.is_valid_errors(seg_data)
         self.assertFalse(result)
-        self.assertEqual([e.err_cde for e in errors], ["1"])
+        self.assertEqual([e.err_cde for e in errors], ["COMP_1_mandatory_missing"])
 
 
 class _RecordingErrh:


### PR DESCRIPTION
Third slice of the X12 error code generalization plan. Composite and segment validators now emit pyx12 codes; visitors translate via the ERROR_CODES table so 999/997 ack output is unchanged.

## Producer migration

`pyx12/map_if/_composite.py` (3 sites):
- Mandatory composite missing: `\"1\"` → `COMP_1_MANDATORY_MISSING`
- Composite marked Not Used: `\"5\"` → `COMP_5_NOT_USED`
- Too many sub-elements: `\"3\"` → `COMP_3_TOO_MANY_SUBELEMENTS`

`pyx12/map_if/_segment.py` (3 sites):
- Too many elements in segment: `\"3\"` → `SEG_3_TOO_MANY_ELEMENTS`
- Too many sub-elements in composite (segment-level check): `\"3\"` → `SEG_3_TOO_MANY_SUBELEMENTS`
- Syntax violations: `\"10\"` → `SEG_10_SYNTAX_EXCLUSIVE`, `\"2\"` → `SEG_2_SYNTAX_RELATIONAL`

## Test updates

4 `test_map_if` assertions updated to expect pyx12 codes:
- `test_segment_length` → `SEG_3_too_many_elements`
- `test_comp_required_fail1` → `COMP_1_mandatory_missing`
- `test_comp_not_used_fail1` → `COMP_5_not_used`
- `test_plb03_composite_missing` → `COMP_1_mandatory_missing`

## resJson fixtures

Unchanged. Re-running the regenerator helper made no diff, confirming no existing resJson fixture exercised composite-level or segment-validator-level error paths. The 39 remaining raw X12 codes in resJson are all from walker/parser emissions, which migrate in PR 4.

## Test plan

- [x] pytest pyx12/test/: **579 passed** (no count change)
- [x] mypy --strict pyx12: clean (88 files)
- [x] ruff check + format --check: clean
- [x] res997/resAck unchanged
- [x] resJson unchanged for these paths (no-op regenerator confirms)

## Plan reference

`~/.claude/plans/radiant-petting-steele.md` — see PR 3 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)