### PR TITLE
test: enforce pyx12 code prefix matches err_handler tree node type

### DIFF
--- a/pyx12/error_codes.py
+++ b/pyx12/error_codes.py
@@ -95,6 +95,7 @@ SEG_4_LOOP_REPEAT_EXCEEDED = "SEG_4_loop_repeat_exceeded"
 # HL1/HL2/LX historically had no ack remap (filtered out).
 SEG_1_INVALID_SEG_ID = "SEG_1_invalid_seg_id"
 SEG_1_LEADING_SPACE = "SEG_1_leading_space"
+SEG_8_HAS_DATA_ELEMENT_ERRORS = "SEG_8_has_data_element_errors"
 SEG_8_SEGMENT_EMPTY = "SEG_8_segment_empty"
 SEG_8_TRAILING_TERMINATORS = "SEG_8_trailing_terminators"
 SEG_8_HL_COUNT_MISMATCH = "SEG_8_hl_count_mismatch"
@@ -317,6 +318,19 @@ ERROR_CODES: dict[str, ErrorCodeSpec] = {
         description="Segment line started with leading whitespace (parser-time)",
         ak_code="1",
         ik_code="1",
+    ),
+    SEG_8_HAS_DATA_ELEMENT_ERRORS: ErrorCodeSpec(
+        code=SEG_8_HAS_DATA_ELEMENT_ERRORS,
+        level="SEG",
+        description=(
+            "Segment has data element errors. Used by apply_segment_errors "
+            "to roll up element-level validator errors (too-many-elements, "
+            "syntax violations, mandatory composite missing, etc.) into a "
+            "spec-correct IK3-04 / AK3-04 code per PR #161. The original "
+            "element-level pyx12 code is preserved in the err_str."
+        ),
+        ak_code="8",
+        ik_code="8",
     ),
     SEG_8_SEGMENT_EMPTY: ErrorCodeSpec(
         code=SEG_8_SEGMENT_EMPTY,

--- a/pyx12/map_if/_segment.py
+++ b/pyx12/map_if/_segment.py
@@ -23,6 +23,7 @@ from ..error_codes import (
     SEG_2_SYNTAX_RELATIONAL,
     SEG_3_TOO_MANY_ELEMENTS,
     SEG_3_TOO_MANY_SUBELEMENTS,
+    SEG_8_HAS_DATA_ELEMENT_ERRORS,
     SEG_10_SYNTAX_EXCLUSIVE,
 )
 from ..error_item import EleError
@@ -61,7 +62,12 @@ def apply_segment_errors(node: segment_if, seg_data: pyx12.segment.Segment, errh
     prev_cursor = None
     for e in errors:
         if e.map_node is None:
-            errh.seg_error("8", e.err_str, e.err_val)
+            # Element-level validator errors collapsed to a seg-level code
+            # per PR #161: use SEG_8_HAS_DATA_ELEMENT_ERRORS so the
+            # err_handler tree carries a SEG_-prefixed code consistent
+            # with where it lands (err_seg.errors). The original
+            # element-level pyx12 code is preserved in e.err_str.
+            errh.seg_error(SEG_8_HAS_DATA_ELEMENT_ERRORS, e.err_str, e.err_val)
             continue
         if e.map_node is not prev_cursor:
             errh.add_ele(e.map_node)

--- a/pyx12/test/test_error_codes.py
+++ b/pyx12/test/test_error_codes.py
@@ -1,0 +1,103 @@
+"""Invariants on the pyx12 error code registry."""
+
+import unittest
+
+from pyx12.error_codes import ERROR_CODES, ErrorCodeSpec, x12_code_for
+
+# Mapping from a pyx12 code-name prefix to the level the code MUST
+# carry in its ErrorCodeSpec. Composites surface as element-level
+# errors in the err_handler tree (composite errors flow through
+# err_ele.errors via apply_segment_errors / errh.ele_error), so
+# COMP_-prefixed codes share the "ELE" level with ELE_ codes.
+PREFIX_TO_LEVEL = {
+    "ELE_": "ELE",
+    "COMP_": "ELE",
+    "SEG_": "SEG",
+}
+
+
+class TableConsistency(unittest.TestCase):
+    """Every code in ERROR_CODES has a name prefix matching its
+    declared ErrorCodeSpec.level. Catches typos like naming a code
+    SEG_3_foo with level="ELE", or an entry whose key string disagrees
+    with its spec.code field."""
+
+    def test_every_code_has_a_known_prefix(self):
+        for code in ERROR_CODES:
+            self.assertTrue(
+                any(code.startswith(p) for p in PREFIX_TO_LEVEL),
+                f"Code {code!r} does not start with any of "
+                f"{tuple(PREFIX_TO_LEVEL)} — extend PREFIX_TO_LEVEL or "
+                f"rename the code.",
+            )
+
+    def test_prefix_matches_spec_level(self):
+        for code, spec in ERROR_CODES.items():
+            for prefix, level in PREFIX_TO_LEVEL.items():
+                if code.startswith(prefix):
+                    self.assertEqual(
+                        spec.level,
+                        level,
+                        f"Code {code!r} has prefix {prefix!r} (level={level}) "
+                        f"but ErrorCodeSpec.level={spec.level!r}",
+                    )
+                    break
+
+    def test_key_matches_spec_code(self):
+        for code, spec in ERROR_CODES.items():
+            self.assertEqual(
+                code,
+                spec.code,
+                f"ERROR_CODES key {code!r} disagrees with ErrorCodeSpec.code={spec.code!r}",
+            )
+
+    def test_ak_and_ik_codes_when_set_are_short_strings(self):
+        # X12 spec codes are 1-3 characters (e.g. "1"-"10", "I4"-"I13").
+        for code, spec in ERROR_CODES.items():
+            for field, value in (("ak_code", spec.ak_code), ("ik_code", spec.ik_code)):
+                if value is None:
+                    continue
+                self.assertIsInstance(value, str)
+                self.assertTrue(
+                    1 <= len(value) <= 3,
+                    f"Code {code!r} {field}={value!r} is not a 1-3 char X12 ack code",
+                )
+
+
+class X12CodeForResolution(unittest.TestCase):
+    """x12_code_for returns the dereferenced X12 code for pyx12 codes
+    in ERROR_CODES, and falls through to err_cde unchanged for codes
+    not in the table (envelope-level passthrough)."""
+
+    def test_known_code_resolves_to_ik_code(self):
+        self.assertEqual(x12_code_for("ELE_8_invalid_date"), "8")
+        self.assertEqual(x12_code_for("SEG_5_segment_repeat_exceeded"), "5")
+
+    def test_unknown_code_falls_through(self):
+        # ISA-level codes like "025" aren't in ERROR_CODES but should
+        # round-trip unchanged for JSON x12_code field rendering.
+        self.assertEqual(x12_code_for("025"), "025")
+        self.assertEqual(x12_code_for("010"), "010")
+
+    def test_ak_preferred_when_ik_is_none(self):
+        # Synthetic spec with ik_code=None -> should fall back to
+        # ak_code in prefer_5010 mode (current implementation: first
+        # consult ik_code, then ak_code).
+        spec = ErrorCodeSpec(
+            code="X_1_synthetic",
+            level="SEG",
+            description="synthetic",
+            ak_code="1",
+            ik_code=None,
+        )
+        # Patch ERROR_CODES temporarily.
+        try:
+            ERROR_CODES[spec.code] = spec
+            self.assertEqual(x12_code_for(spec.code, prefer_5010=True), "1")
+            self.assertEqual(x12_code_for(spec.code, prefer_5010=False), "1")
+        finally:
+            del ERROR_CODES[spec.code]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyx12/test/test_map_if.py
+++ b/pyx12/test/test_map_if.py
@@ -796,6 +796,6 @@ class ApplySegmentErrorsRouting(unittest.TestCase):
         errh = _RecordingErrh()
         ok = self.apply(ref_node, seg_data, errh)
         self.assertFalse(ok)
-        self.assertIn(("seg_error", "8", None), errh.calls)
+        self.assertIn(("seg_error", "SEG_8_has_data_element_errors", None), errh.calls)
         self.assertFalse(any(c[0] == "ele_error" for c in errh.calls))
         self.assertFalse(any(c[0] == "add_ele" for c in errh.calls))

--- a/pyx12/test/test_x12n_document.py
+++ b/pyx12/test/test_x12n_document.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pyx12.error_handler
 import pyx12.params
+import pyx12.x12context
 import pyx12.x12n_document
 from pyx12.test.x12testdata import datafiles
 
@@ -298,6 +299,92 @@ class UnicodeInput(X12DocumentTestCase):
             pyx12.x12n_document.x12n_document(self.param, temppath, fd_997, None, None)
         finally:
             os.unlink(temppath)
+
+
+class ErrorCodePrefixPlacement(X12DocumentTestCase):
+    """The pyx12 code prefix must match the X12 node type in the
+    err_handler tree:
+
+    * Codes stored on err_seg.errors must start with ``SEG_``.
+    * Codes stored on err_ele.errors must start with ``ELE_`` or
+      ``COMP_`` (composites surface as element-level errors).
+
+    Verified by running representative fixtures through x12n_document
+    and walking the resulting err_handler tree."""
+
+    def _walk_tree(self, datakey: str) -> pyx12.error_handler.err_handler:
+        errh = pyx12.error_handler.err_handler()
+        fd_source = self._makeFd(datafiles[datakey]["source"])
+        fd_997 = StringIO()
+        fd_html = StringIO()
+        # x12n_document creates its own err_handler internally, so we
+        # can't pass ours. Drive X12ContextReader instead — it accepts
+        # a caller-provided errh and threads it through (PR #166).
+        src = pyx12.x12context.X12ContextReader(self.param, errh, fd_source)
+        for _ in src.iter_segments():
+            pass
+        return errh
+
+    def _collect(self, errh: pyx12.error_handler.err_handler) -> tuple[list[str], list[str]]:
+        seg_codes: list[str] = []
+        ele_codes: list[str] = []
+        for isa in errh.children:
+            for gs in isa.children:
+                for st in gs.children:
+                    for seg in st.children:
+                        seg_codes.extend(c for c, *_ in seg.errors)
+                        for ele in seg.elements:
+                            ele_codes.extend(c for c, *_ in ele.errors)
+        return seg_codes, ele_codes
+
+    def test_walker_seg_errors_have_seg_prefix(self):
+        # bad_2010AA_bug -> walker emits SEG_3_mandatory_loop_missing.
+        errh = self._walk_tree("bad_2010AA_bug")
+        seg_codes, _ = self._collect(errh)
+        self.assertTrue(seg_codes, "expected at least one seg-level error")
+        for code in seg_codes:
+            self.assertTrue(
+                code.startswith("SEG_"),
+                f"seg-level err_cde {code!r} does not start with SEG_",
+            )
+
+    def test_validator_ele_errors_have_ele_or_comp_prefix(self):
+        # 834_lui_id_5010_non_ascii -> ELE_6_invalid_type_char on REF02.
+        errh = self._walk_tree("834_lui_id_5010_non_ascii")
+        _, ele_codes = self._collect(errh)
+        self.assertTrue(ele_codes, "expected at least one element-level error")
+        for code in ele_codes:
+            self.assertTrue(
+                code.startswith("ELE_") or code.startswith("COMP_"),
+                f"element-level err_cde {code!r} does not start with ELE_ or COMP_",
+            )
+
+    def test_no_raw_x12_code_leaks_into_seg_or_ele_errors(self):
+        # Run several fixtures through and verify the prefix invariant
+        # holds across the corpus.
+        for datakey in (
+            "bad_2010AA_bug",
+            "834_lui_id_5010_non_ascii",
+            "elements",
+            "trailing_terms",
+            "loop_counting",
+            "loop_counting2",
+            "multiple_trn",
+        ):
+            with self.subTest(datakey=datakey):
+                errh = self._walk_tree(datakey)
+                seg_codes, ele_codes = self._collect(errh)
+                for code in seg_codes:
+                    self.assertTrue(
+                        code.startswith("SEG_"),
+                        f"[{datakey}] seg-level err_cde {code!r} is not a SEG_-prefixed pyx12 code",
+                    )
+                for code in ele_codes:
+                    self.assertTrue(
+                        code.startswith("ELE_") or code.startswith("COMP_"),
+                        f"[{datakey}] element-level err_cde {code!r} is not "
+                        f"an ELE_- or COMP_-prefixed pyx12 code",
+                    )
 
 
 class SuppressErrorCodes(X12DocumentTestCase):


### PR DESCRIPTION
Add unit-test invariants that pyx12 code prefixes match where the error attaches in the err_handler tree:

- `ELE_*` and `COMP_*` codes must land in `err_ele.errors` (composites surface as element-level errors).
- `SEG_*` codes must land in `err_seg.errors`.

Also fix the one place that violated this invariant: the historical PR #161 hardcode in `apply_segment_errors` that stored a literal `\"8\"` in `err_seg.errors` when collapsing element-level validator errors (too-many-elements, syntax violations, mandatory composite missing) to a spec-correct IK3 code. Replace with new pyx12 code `SEG_8_HAS_DATA_ELEMENT_ERRORS` (ak/ik=`\"8\"`); ack output unchanged because the visitor still resolves to `\"8\"` via the table, and the original element-level pyx12 code is preserved in the err_str.

## New tests

**`pyx12/test/test_error_codes.py`** (new file):
- `TableConsistency.test_every_code_has_a_known_prefix`
- `TableConsistency.test_prefix_matches_spec_level` — the main invariant: every code's name prefix matches its declared `ErrorCodeSpec.level`
- `TableConsistency.test_key_matches_spec_code`
- `TableConsistency.test_ak_and_ik_codes_when_set_are_short_strings`
- `X12CodeForResolution.test_known_code_resolves_to_ik_code`
- `X12CodeForResolution.test_unknown_code_falls_through` — envelope-level codes (`\"025\"`) passthrough
- `X12CodeForResolution.test_ak_preferred_when_ik_is_none`

**`pyx12/test/test_x12n_document.py`** (new `ErrorCodePrefixPlacement` class):
- `test_walker_seg_errors_have_seg_prefix` — uses `bad_2010AA_bug`
- `test_validator_ele_errors_have_ele_or_comp_prefix` — uses `834_lui_id_5010_non_ascii`
- `test_no_raw_x12_code_leaks_into_seg_or_ele_errors` — parameterized across 7 fixtures

## Updates

- `pyx12/error_codes.py` — new `SEG_8_HAS_DATA_ELEMENT_ERRORS` constant + ERROR_CODES entry
- `pyx12/map_if/_segment.py` `apply_segment_errors` — emit `SEG_8_HAS_DATA_ELEMENT_ERRORS` instead of literal `\"8\"`
- `pyx12/test/test_map_if.py` — `ApplySegmentErrorsRouting` test updated to expect the new code

## Test plan

- [x] pytest pyx12/test/: **597 passed + 7 subtests** (581 + 6 from PR #180 + 10 new from this PR)
- [x] mypy --strict pyx12: clean (89 source files; new `test_error_codes.py`)
- [x] ruff check + format --check: clean
- [x] res997 / resAck / resJson fixtures unchanged — the `apply_segment_errors` collapse path is not exercised by any existing fixture (regenerator helper run, no diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)